### PR TITLE
Edit pass: spelling, trailing space, and CRLF

### DIFF
--- a/README.expressions.md
+++ b/README.expressions.md
@@ -16,7 +16,7 @@ Pixelblaze looks for a few exported functions that it can call to generate pixel
 
 The exported `render(index)` function is called for each pixel in the strip. The `index` argument tells you which pixel is being rendered. Use the `hsv` or `rgb` function to set the current pixel's color.
 
-The exported `beforeRender(delta)` function is called before it is going to render a new frame of pixels to the strip. The `delta` argument is the number of ellapsed milliseconds (with a resulution of 6.25ns!) since the last time `beforeRender` was called. You can use `delta` to create animations that run at the same speed regardless of the frame rate.
+The exported `beforeRender(delta)` function is called before it is going to render a new frame of pixels to the strip. The `delta` argument is the number of elapsed milliseconds (with a resolution of 6.25ns!) since the last time `beforeRender` was called. You can use `delta` to create animations that run at the same speed regardless of the frame rate.
 
 Pixelblaze's language is based off of JavaScript (ES6) syntax, but with a subset of the language features available. All numbers in Pixelblaze are a 16.16 fixed-point numbers. This can handle values between -32,768 to +32,768 with fractional accuracy down to 1/65,536ths.
 
@@ -26,7 +26,7 @@ A global called `pixelCount` is defined based on how many pixels you've configur
 # Supported Language Features
 
 * All of the usual math operators work. Most work on 16.16 fixed-point math. The bit-wise operators work on the top 16 bits. `=`, `+`, `-`, `!`, `*`, `/`, `%`, `>>`, `<<`, `~`, `^`, `>`, `<`, `>=`, `<=`, `==`, `!=`, `||`, `&&`, `?`
-* Logical operators work like JavaScript and carry over the value, not just a boolean. e.g. `v = 0 || 42` will result in 42. 
+* Logical operators work like JavaScript and carry over the value, not just a boolean. e.g. `v = 0 || 42` will result in 42.
 * Trig and other math functions. `abs`, `floor`, `ceil`, `min`, `max`, `clamp`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sqrt`, `exp`, `log`, `log2`, `pow`, `random`
 * Declare global or function-local variables using `var` or globals implicitly.
 * Use `if` and `else` to have some code run conditionally.
@@ -34,21 +34,21 @@ A global called `pixelCount` is defined based on how many pixels you've configur
 * Define functions using the `function` keyword or short lambda-style form.
   * `function myFunction(arg1) {return arg1 * 2}`
   * `myFunction = (arg1) => arg1 * 2`
-* Functions can be stored in variables, passed as arguments, and returned from other functions. 
+* Functions can be stored in variables, passed as arguments, and returned from other functions.
 * Create arrays using the `array(size)` function and access them with the bracket syntax. Arrays can be passed around just like any other type.
 
 # Language limitations
 
-This are language features you'd expect to work writing JavaScript that won't run on Pixelblaze. 
+This are language features you'd expect to work writing JavaScript that won't run on Pixelblaze.
 
 * Objects, named properties, classes, etc.
-* Garbage collection or freeing memory. Arrays are currently the only dynamically allocated memory, and you can't (yet) free them once created. 
-* Closures aren't supported, so any function defined in another function won't have access to parameters or local varables. It can still access globals or its own parameters. 
+* Garbage collection or freeing memory. Arrays are currently the only dynamically allocated memory, and you can't (yet) free them once created.
+* Closures aren't supported, so any function defined in another function won't have access to parameters or local variables. It can still access globals or its own parameters.
 * `switch` + `case` statements. You can use chained `else if` statements, or put functions in an array and use it as a lookup table.
 
 ```
-modes[0] = () => {/* do mode 0 */}; 
-modes[1] = () => {/* do mode 1 */}; 
+modes[0] = () => {/* do mode 0 */};
+modes[1] = () => {/* do mode 1 */};
 // ...
 modes[currentMode]();
 ```
@@ -58,7 +58,7 @@ modes[currentMode]();
 
 # Variables
 
-The `pixelCount` variable is available as a global even during initialization. This is the number of LED pixels that have been configured in settings. 
+The `pixelCount` variable is available as a global even during initialization. This is the number of LED pixels that have been configured in settings.
 
 Variables can be created/assigned implicitly with the `=` operator. e.g.: `foo = sin(time(0.1,PI2))` or explicitly using the `var` keyword. e.g.: `var foo = 1`.
 
@@ -72,7 +72,7 @@ You can also declare local variables inside functions using the `var` keyword.
 # Functions
 
 ### Math Functions
-    
+
 #### abs(`v`)
 #### acos(`x`)
 #### asin(`x`)
@@ -94,12 +94,12 @@ A random number between 0.0 and `max` (exclusive)
 #### sin(`angleRads`)
 #### sqrt(`angleRads`)
 #### tan(`angleRads`)
-    
-### Waveform Functions
-    
-#### time(`interval`)  
 
-A sawtooth waveform between 0.0 and 1.0 that loops about every 65.536*`interval` seconds. e.g. use .015 for an aproximately 1 second.
+### Waveform Functions
+
+#### time(`interval`)
+
+A sawtooth waveform between 0.0 and 1.0 that loops about every 65.536*`interval` seconds. e.g. use .015 for an approximately 1 second.
 #### wave(`v`)
 
 Converts a sawtooth waveform `v` between 0.0 and 1.0 to a sinusoidal waveform between 0.0 to 1.0. Same as `(1+sin(v*PI2))/2` but faster. `v` "wraps" between 0.0 and 1.0.
@@ -107,20 +107,20 @@ Converts a sawtooth waveform `v` between 0.0 and 1.0 to a sinusoidal waveform be
 Converts a sawtooth waveform `v` to a square wave using the provided `duty` cycle where `duty` is a number between 0.0 and 1.0. `v` "wraps" between 0.0 and 1.0.
 #### triangle(`v`)
 Converts a sawtooth waveform `v` between 0.0 and 1.0 to a triangle waveform between 0.0 to 1.0. `v` "wraps" between 0.0 and 1.0.
-    
+
 ### Pixel / Color Functions
-    
+
 #### hsv(`hue`, `saturation`, `value`)
 
-Sets the current pixel by calculating the RGB values based on the HSV color space. `Hue` "wraps" between 0.0 and 1.0. Nevative values wrap backwards. For LEDs that support it, this uses 24-bit color plus an additional 5 bits of brightness control giving a high dynamic range especially at lower light levels and reduces posterization.
+Sets the current pixel by calculating the RGB values based on the HSV color space. `Hue` "wraps" between 0.0 and 1.0. Negative values wrap backwards. For LEDs that support it, this uses 24-bit color plus an additional 5 bits of brightness control giving a high dynamic range especially at lower light levels and reduces posterization.
 
 #### hsv24(`hue`, `saturation`, `value`)
 
-Sets the current pixel by calculating the RGB values based on the HSV color space. `Hue` "wraps" between 0.0 and 1.0. Nevative values wrap backwards. This uses 24-bit color only, even if the LEDs support additional resolution and may reduce flickering in some LEDs.
+Sets the current pixel by calculating the RGB values based on the HSV color space. `Hue` "wraps" between 0.0 and 1.0. Negative values wrap backwards. This uses 24-bit color only, even if the LEDs support additional resolution and may reduce flickering in some LEDs.
 
 #### rgb(`red`, `green`, `blue`)
 
-Sets the current pixel to the RGB value provided. Values range between 0.0 and 1.0. 
+Sets the current pixel to the RGB value provided. Values range between 0.0 and 1.0.
 
 ### Input / Output Functions
 
@@ -136,7 +136,7 @@ Set the pin mode as an `INPUT`, `INPUT_PULLUP`, `INPUT_PULLDOWN_16`, `OUTPUT`, o
 `INPUT_PULLDOWN_16` works only for GP16. Can be used with a button, connect between GP16 and 3.3v. Pins will read `HIGH` or 1.0 while the button is pressed.
 
 #### digitalWrite(`pin`,`state`)
-Set a pin `HIGH` or `LOW`. Any non-zero value wil set the pin `HIGH`.
+Set a pin `HIGH` or `LOW`. Any non-zero value will set the pin `HIGH`.
 
 #### digitalRead(`pin`)
 Read a pin state, returns 1.0 if the pin is `HIGH`, 0.0 for `LOW` otherwise.

--- a/README.mapper.md
+++ b/README.mapper.md
@@ -9,13 +9,13 @@
 
 The pixel mapper allows you to generate patterns that are aware of the physical LED layout. This can be used for matrix arrays, LED rings, costumes, or pretty much anything you can imagine!
 
-Each pixel is still rendered one at a time, but special render functions take arguments that give coordinate information. The original linear `render(index)` takes just an integer pixel index, but `render2D(index, x, y)` and `render3D(index, x, y, z)` add additional coordinate information in "world units" - a value between 0.0 and 1.0. 
+Each pixel is still rendered one at a time, but special render functions take arguments that give coordinate information. The original linear `render(index)` takes just an integer pixel index, but `render2D(index, x, y)` and `render3D(index, x, y, z)` add additional coordinate information in "world units" - a value between 0.0 and 1.0.
 
-By using "world units" patterns can be written for any possible configuation without having to know the the size of the world.
+By using "world units" patterns can be written for any possible configuration without having to know the size of the world.
 
 The editor automatically scales input coordinates to world units. This lets you enter real physical dimensions, which are automatically converted. As long as you use the same unit, you can input coordinates using inches, millimeters, pixels, etc. The world size will be calculated based on the limits of the map, and the coordinates will be converted to positions inside that world.
 
-# Rendering with Pixel Maps 
+# Rendering with Pixel Maps
 
 To use pixel map data, implement and export a render2D or render3D function. e.g. on a matrix this will show a fading rainbow gradient:
 
@@ -28,7 +28,7 @@ export function render2D(index, x, y) {
 Likewise, render3D can produce a HSV volumetric cube showing all color capabilities:
 
 ```
-export function render3D(index, x, y) {
+export function render3D(index, x, y, z) {
 	hsv(x, y, z)
 }
 ```
@@ -41,7 +41,7 @@ The world units work very similarly to using something like `index/pixelCount`, 
 
 The editor can accept a plain JSON array of arrays or a JavaScript value that evaluates to one. Each element in the top level array represents a pixel. Within a pixel, an array with elements for the x, y, and optionally z coordinate.
 
-For example here is a box with 4 pixels, one in each corner: top left, top right, bottom right, and finally bottom left. 
+For example here is a box with 4 pixels, one in each corner: top left, top right, bottom right, and finally bottom left.
 
 ```
 [

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pixelblaze
 [https://www.bhencke.com/pixelblaze](https://www.bhencke.com/pixelblaze)
 
-This repo includes a few files related to Pixelblaze. 
+This repo includes a few files related to Pixelblaze.
 
 Pixelblaze itself isn't open source (yet), though some of its components are!
 * [https://github.com/simap/Apa102Adapter](https://github.com/simap/Apa102Adapter)


### PR DESCRIPTION
Small fixes to Pixelblaze documentation:
- Some spelling errors, and removing one repeated "the the".
- Removed some trailing whitespace.
- Remove a few scattered CRLF so files are now consistently LF throughout.