### PR TITLE
PICO pcb reworked

### DIFF
--- a/V3/hardware/PB32Pico_1.x.brd
+++ b/V3/hardware/PB32Pico_1.x.brd
@@ -6,10 +6,10 @@
 <setting alwaysvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="20" unitdist="mil" unit="mil" style="lines" multiple="1" display="no" altdistance="1" altunitdist="mil" altunit="mil"/>
+<grid distance="0.05" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="1" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
-<layer number="2" name="Route2" color="24" fill="1" visible="yes" active="yes"/>
+<layer number="2" name="Route2" color="24" fill="1" visible="no" active="yes"/>
 <layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
 <layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
 <layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
@@ -22,50 +22,52 @@
 <layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
 <layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
 <layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
-<layer number="15" name="Route15" color="13" fill="1" visible="yes" active="yes"/>
-<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="15" name="Route15" color="13" fill="1" visible="no" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="yes"/>
 <layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="20" name="Dimension" color="24" fill="1" visible="yes" active="yes"/>
 <layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="yes"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="29" name="tStop" color="7" fill="3" visible="yes" active="yes"/>
-<layer number="30" name="bStop" color="7" fill="6" visible="yes" active="yes"/>
-<layer number="31" name="tCream" color="7" fill="4" visible="yes" active="yes"/>
-<layer number="32" name="bCream" color="7" fill="5" visible="yes" active="yes"/>
-<layer number="33" name="tFinish" color="6" fill="3" visible="yes" active="yes"/>
-<layer number="34" name="bFinish" color="6" fill="6" visible="yes" active="yes"/>
-<layer number="35" name="tGlue" color="7" fill="4" visible="yes" active="yes"/>
-<layer number="36" name="bGlue" color="7" fill="5" visible="yes" active="yes"/>
-<layer number="37" name="tTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="38" name="bTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
-<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
-<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
-<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
-<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
-<layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="46" name="Milling" color="3" fill="1" visible="yes" active="yes"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
 <layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="yes"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
 <layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="58" name="bCAD" color="9" fill="1" visible="no" active="no"/>
 <layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="61" name="stand" color="7" fill="1" visible="no" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="no" active="no"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="no" active="no"/>
 <layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
@@ -79,85 +81,87 @@
 <layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
 <layer number="99" name="SpiceOrder" color="7" fill="1" visible="no" active="no"/>
 <layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
-<layer number="101" name="Patch_Top" color="12" fill="4" visible="yes" active="yes"/>
-<layer number="102" name="Vscore" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="103" name="tMap" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="104" name="Name" color="16" fill="1" visible="yes" active="yes"/>
-<layer number="105" name="tPlate" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="106" name="bPlate" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="107" name="Crop" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="108" name="tplace-old" color="10" fill="1" visible="yes" active="yes"/>
-<layer number="109" name="ref-old" color="11" fill="1" visible="yes" active="yes"/>
-<layer number="110" name="fp0" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="111" name="LPC17xx" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="112" name="tSilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="113" name="IDFDebug" color="4" fill="1" visible="yes" active="yes"/>
-<layer number="114" name="Badge_Outline" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="16" fill="1" visible="no" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="tplace-old" color="10" fill="1" visible="no" active="yes"/>
+<layer number="109" name="ref-old" color="11" fill="1" visible="no" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="no" active="yes"/>
+<layer number="111" name="LPC17xx" color="7" fill="1" visible="no" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="113" name="IDFDebug" color="4" fill="1" visible="no" active="yes"/>
+<layer number="114" name="Badge_Outline" color="7" fill="1" visible="no" active="yes"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
 <layer number="117" name="BACKMAAT1" color="7" fill="1" visible="no" active="no"/>
-<layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
 <layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="no" active="no"/>
 <layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="no" active="no"/>
-<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="126" name="_bNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="127" name="_tValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="128" name="_bValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="no" active="yes"/>
 <layer number="130" name="SMDSTROOK" color="7" fill="1" visible="no" active="no"/>
-<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
 <layer number="133" name="bottom_silk" color="7" fill="1" visible="no" active="no"/>
 <layer number="134" name="silk_top" color="7" fill="1" visible="no" active="no"/>
 <layer number="135" name="silk_bottom" color="7" fill="1" visible="no" active="no"/>
-<layer number="136" name="silktop" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="137" name="silkbottom" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="138" name="mbTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="139" name="mtKeepout" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="140" name="mbKeepout" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="141" name="mtRestrict" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="142" name="mbRestrict" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="143" name="mvRestrict" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="145" name="DrillLegend_01-16" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="146" name="DrillLegend_01-20" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="147" name="mMeasures" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="148" name="mDocument" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="149" name="mReference" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="153" name="FabDoc1" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="154" name="FabDoc2" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="155" name="FabDoc3" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="191" name="mNets" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="192" name="mBusses" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="193" name="mPins" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="194" name="mSymbols" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="195" name="mNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="196" name="mValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="136" name="silktop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="137" name="silkbottom" color="7" fill="1" visible="no" active="yes"/>
+<layer number="138" name="mbTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="139" name="mtKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="140" name="mbKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="141" name="mtRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="142" name="mbRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="143" name="mvRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="145" name="DrillLegend_01-16" color="7" fill="1" visible="no" active="yes"/>
+<layer number="146" name="DrillLegend_01-20" color="7" fill="1" visible="no" active="yes"/>
+<layer number="147" name="mMeasures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="148" name="mDocument" color="7" fill="1" visible="no" active="yes"/>
+<layer number="149" name="mReference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="166" name="AntennaArea" color="7" fill="1" visible="no" active="yes"/>
+<layer number="168" name="4mmHeightArea" color="7" fill="1" visible="no" active="yes"/>
+<layer number="191" name="mNets" color="7" fill="1" visible="no" active="yes"/>
+<layer number="192" name="mBusses" color="7" fill="1" visible="no" active="yes"/>
+<layer number="193" name="mPins" color="7" fill="1" visible="no" active="yes"/>
+<layer number="194" name="mSymbols" color="7" fill="1" visible="no" active="yes"/>
+<layer number="195" name="mNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="196" name="mValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
 <layer number="200" name="200bmp" color="1" fill="10" visible="no" active="no"/>
-<layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
-<layer number="202" name="202bmp" color="3" fill="10" visible="yes" active="yes"/>
-<layer number="203" name="203bmp" color="4" fill="10" visible="yes" active="yes"/>
-<layer number="204" name="204bmp" color="5" fill="10" visible="yes" active="yes"/>
-<layer number="205" name="205bmp" color="6" fill="10" visible="yes" active="yes"/>
-<layer number="206" name="206bmp" color="7" fill="10" visible="yes" active="yes"/>
-<layer number="207" name="207bmp" color="8" fill="10" visible="yes" active="yes"/>
-<layer number="208" name="208bmp" color="9" fill="10" visible="yes" active="yes"/>
-<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
 <layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
 <layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
 <layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
@@ -166,30 +170,32 @@
 <layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
 <layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
 <layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
-<layer number="225" name="225bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="226" name="226bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="227" name="227bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="228" name="228bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="229" name="229bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="230" name="230bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="231" name="231bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="231" name="231bmp" color="7" fill="1" visible="no" active="yes"/>
 <layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="no"/>
 <layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="no"/>
-<layer number="248" name="Housing" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="249" name="Edge" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
 <layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
 <layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
-<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="255" name="routoute" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
 </layers>
 <board>
+<fusionsync huburn="a.cGVyc29uYWw6dWUyYWE4ZDY4" projecturn="a.cGVyc29uYWw6dWUyYWE4ZDY4IzIwMjIwNDIzNTE5MzQ1OTgx" f3durn="urn:adsk.wipprod:dm.lineage:Ic-RW6KrQpW8w4gEzOK9OQ" pcbguid="" lastpulledtime="" lastsyncedchangeguid="" latestrevisionid="9810644f-0e8d-4da9-a1f0-40bb9a413041" lastsyncedrevisionid="9810644f-0e8d-4da9-a1f0-40bb9a413041" lastboardhashguid="569b8a02-a8cb-a9a2-795f-895e3a5c6d2e" lastpushedtime="2022-04-23T11:27:03Z" linktopcb3d="true"/>
 <plain>
 <wire x1="0" y1="0" x2="33.32" y2="0" width="0" layer="20"/>
 <wire x1="33.32" y1="0" x2="33.32" y2="10.846" width="0" layer="20"/>
 <wire x1="33.32" y1="10.846" x2="0" y2="10.846" width="0" layer="20"/>
 <wire x1="0" y1="10.846" x2="0" y2="0" width="0" layer="20"/>
-<text x="24.831" y="0.635" size="0.7" layer="21">Pixelblaze Pico
-2020 Ben Hencke</text>
+<text x="24.781" y="0.135" size="0.7" layer="21">Pixelblaze Pico
+2020 Ben Hencke
+2022 Ebucci</text>
 <text x="3.495" y="8.89" size="1.016" layer="22" rot="MR0">G</text>
 <text x="3.495" y="6.223" size="1.016" layer="22" rot="MR0">D</text>
 <text x="3.495" y="3.683" size="1.016" layer="22" rot="MR0">C</text>
@@ -199,7 +205,7 @@
 2020 
 Ben Hencke</text>
 <text x="25.212" y="9.398" size="0.7" layer="21">electromage.com</text>
-<text x="26.863" y="2.921" size="1.016" layer="21">v1.8</text>
+<text x="26.063" y="4.021" size="1.016" layer="21">v1.8</text>
 <text x="32.832" y="4.318" size="1.016" layer="22" rot="MR0">v1.8</text>
 <text x="2.987" y="8.89" size="1.016" layer="21">G</text>
 <text x="2.987" y="6.223" size="1.016" layer="21">D</text>
@@ -213,40 +219,6 @@ Ben Hencke</text>
 <text x="11.115" y="8.001" size="1.016" layer="22" rot="MR0">3v</text>
 </plain>
 <libraries>
-<library name="SparkFun-PowerIC">
-<description>&lt;h3&gt;SparkFun Electronics' preferred foot prints&lt;/h3&gt;
-In this library you'll find drivers, regulators, and amplifiers.&lt;br&gt;&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is the end user's responsibility to ensure correctness and suitablity for a given componet or application. If you enjoy using this library, please buy one of our products at www.sparkfun.com.
-&lt;br&gt;&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
-<packages>
-<package name="SOT23-5">
-<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt;</description>
-<wire x1="1.27" y1="0.4294" x2="1.27" y2="-0.4294" width="0.2032" layer="21"/>
-<wire x1="1.4" y1="-0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
-<wire x1="-1.27" y1="-0.4294" x2="-1.27" y2="0.4294" width="0.2032" layer="21"/>
-<wire x1="-1.4" y1="0.8" x2="1.4" y2="0.8" width="0.1524" layer="51"/>
-<wire x1="-0.2684" y1="0.7088" x2="0.2684" y2="0.7088" width="0.2032" layer="21"/>
-<wire x1="1.4" y1="0.8" x2="1.4" y2="-0.8" width="0.1524" layer="51"/>
-<wire x1="-1.4" y1="0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
-<rectangle x1="-1.2" y1="-1.5" x2="-0.7" y2="-0.85" layer="51"/>
-<rectangle x1="-0.25" y1="-1.5" x2="0.25" y2="-0.85" layer="51"/>
-<rectangle x1="0.7" y1="-1.5" x2="1.2" y2="-0.85" layer="51"/>
-<rectangle x1="0.7" y1="0.85" x2="1.2" y2="1.5" layer="51"/>
-<rectangle x1="-1.2" y1="0.85" x2="-0.7" y2="1.5" layer="51"/>
-<smd name="1" x="-0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="2" x="0" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="3" x="0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="4" x="0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="5" x="-0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
-<text x="-0.889" y="2.159" size="0.4064" layer="25">&gt;NAME</text>
-<text x="-0.9525" y="-0.1905" size="0.4064" layer="27">&gt;VALUE</text>
-<circle x="-1.6002" y="-1.016" radius="0.127" width="0" layer="21"/>
-</package>
-</packages>
-</library>
 <library name="SparkFun-Connectors" urn="urn:adsk.eagle:library:513">
 <description>&lt;h3&gt;SparkFun Connectors&lt;/h3&gt;
 This library contains electrically-functional connectors. 
@@ -340,972 +312,6 @@ CONN_04
 </description>
 <packageinstances>
 <packageinstance name="1X04_NO_SILK"/>
-</packageinstances>
-</package3d>
-</packages3d>
-</library>
-<library name="SparkFun-Resistors" urn="urn:adsk.eagle:library:532">
-<description>&lt;h3&gt;SparkFun Resistors&lt;/h3&gt;
-This library contains resistors. Reference designator:R. 
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
-<packages>
-<package name="0603" urn="urn:adsk.eagle:footprint:39615/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 1608 (0603) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-1.6" y1="0.7" x2="1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="0.7" x2="1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="-0.7" x2="-1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="-1.6" y1="-0.7" x2="-1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
-<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
-<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<text x="0" y="0.762" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.762" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
-<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="0603" urn="urn:adsk.eagle:package:39650/1" type="box" library_version="1">
-<description>Generic 1608 (0603) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="0603"/>
-</packageinstances>
-</package3d>
-</packages3d>
-</library>
-<library name="SparkFun-Capacitors" urn="urn:adsk.eagle:library:510">
-<description>&lt;h3&gt;SparkFun Capacitors&lt;/h3&gt;
-This library contains capacitors. 
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
-<packages>
-<package name="0603" urn="urn:adsk.eagle:footprint:37386/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 1608 (0603) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-1.6" y1="0.7" x2="1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="0.7" x2="1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="-0.7" x2="-1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="-1.6" y1="-0.7" x2="-1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
-<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
-<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<text x="0" y="0.762" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.762" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
-<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-</package>
-<package name="0402" urn="urn:adsk.eagle:footprint:37389/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 1005 (0402) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-0.2704" y1="0.2286" x2="0.2704" y2="0.2286" width="0.1524" layer="51"/>
-<wire x1="0.2704" y1="-0.2286" x2="-0.2704" y2="-0.2286" width="0.1524" layer="51"/>
-<wire x1="-1.2" y1="0.65" x2="1.2" y2="0.65" width="0.0508" layer="39"/>
-<wire x1="1.2" y1="0.65" x2="1.2" y2="-0.65" width="0.0508" layer="39"/>
-<wire x1="1.2" y1="-0.65" x2="-1.2" y2="-0.65" width="0.0508" layer="39"/>
-<wire x1="-1.2" y1="-0.65" x2="-1.2" y2="0.65" width="0.0508" layer="39"/>
-<smd name="1" x="-0.58" y="0" dx="0.85" dy="0.9" layer="1"/>
-<smd name="2" x="0.58" y="0" dx="0.85" dy="0.9" layer="1"/>
-<text x="0" y="0.762" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.762" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.3048" layer="51"/>
-<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.3048" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="0603" urn="urn:adsk.eagle:package:37414/1" type="box" library_version="1">
-<description>Generic 1608 (0603) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="0603"/>
-</packageinstances>
-</package3d>
-<package3d name="0402" urn="urn:adsk.eagle:package:37413/1" type="box" library_version="1">
-<description>Generic 1005 (0402) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="0402"/>
-</packageinstances>
-</package3d>
-</packages3d>
-</library>
-<library name="SOP50P310X90-8N">
-<packages>
-<package name="SOP50P310X90-8N">
-<text x="-3.09725" y="-1.638140625" size="1.6955" layer="27" align="top-left">&gt;VALUE</text>
-<text x="-3.179609375" y="1.681640625" size="1.74053125" layer="25">&gt;NAME</text>
-<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="21"/>
-<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="51"/>
-<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="51"/>
-<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="51"/>
-<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="21"/>
-<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="21"/>
-<wire x1="-1.15" y1="1" x2="-1.15" y2="-1" width="0.127" layer="51"/>
-<wire x1="1.15" y1="1" x2="1.15" y2="-1" width="0.127" layer="51"/>
-<wire x1="-2.215" y1="1.25" x2="2.215" y2="1.25" width="0.05" layer="39"/>
-<wire x1="-2.215" y1="-1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
-<wire x1="-2.215" y1="1.25" x2="-2.215" y2="-1.25" width="0.05" layer="39"/>
-<wire x1="2.215" y1="1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
-<smd name="1" x="-1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="2" x="-1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="3" x="-1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="4" x="-1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="5" x="1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="6" x="1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="7" x="1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="8" x="1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-</package>
-</packages>
-</library>
-<library name="SparkFun-Switches" urn="urn:adsk.eagle:library:535">
-<description>&lt;h3&gt;SparkFun Switches, Buttons, Encoders&lt;/h3&gt;
-In this library you'll find switches, buttons, joysticks, and anything that moves to create or disrupt an electrical connection.
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
-<packages>
-<package name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:footprint:40111/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/Buttons/SMD-Button.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
-<wire x1="-1.54" y1="-2.54" x2="-2.54" y2="-1.54" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-1.24" x2="-2.54" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="1.54" x2="-1.54" y2="2.54" width="0.2032" layer="51"/>
-<wire x1="-1.54" y1="2.54" x2="1.54" y2="2.54" width="0.2032" layer="21"/>
-<wire x1="1.54" y1="2.54" x2="2.54" y2="1.54" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="1.24" x2="2.54" y2="-1.24" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-1.54" x2="1.54" y2="-2.54" width="0.2032" layer="51"/>
-<wire x1="1.54" y1="-2.54" x2="-1.54" y2="-2.54" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="1.905" y2="0.445" width="0.127" layer="51"/>
-<wire x1="1.905" y1="0.445" x2="2.16" y2="-0.01" width="0.127" layer="51"/>
-<wire x1="1.905" y1="-0.23" x2="1.905" y2="-1.115" width="0.127" layer="51"/>
-<circle x="0" y="0" radius="1.27" width="0.2032" layer="21"/>
-<smd name="1" x="-2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<smd name="2" x="2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<smd name="3" x="-2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<smd name="4" x="2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<text x="0" y="2.667" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-2.667" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-</packages>
-<packages3d>
-<package3d name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:package:40167/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Dimensional Drawing</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_5.2MM"/>
-</packageinstances>
-</package3d>
-</packages3d>
-</library>
-<library name="bens">
-<packages>
-<package name="CHIPANTENNA-1206-SHORT">
-<circle x="-0.7" y="0" radius="0.360553125" width="0.127" layer="21"/>
-<rectangle x1="-1.75" y1="-0.9" x2="1.75" y2="0.9" layer="51"/>
-<rectangle x1="-3.75" y1="-0.9" x2="-1.75" y2="0.9" layer="1"/>
-<wire x1="-3.75" y1="4" x2="-3.75" y2="-4" width="0.0762" layer="51"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="1"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="1"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="31"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="31"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="29"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="29"/>
-<smd name="P$1" x="-3.7" y="0" dx="0.1" dy="1.8" layer="1" stop="no" thermals="no" cream="no"/>
-<text x="-3" y="1.3" size="0.4" layer="51" rot="R90">GND Line</text>
-</package>
-<package name="PICO-D4-QFN48">
-<description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
-48 Quad Flat Package No Leads&lt;br&gt;
-Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
-<circle x="-3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.5" y="2.5" radius="0.4" width="0" layer="51"/>
-<wire x1="-3" y1="3.5" x2="3" y2="3.5" width="0.1016" layer="51"/>
-<wire x1="3" y1="3.5" x2="3.5" y2="3" width="0.1016" layer="51"/>
-<wire x1="3.5" y1="3" x2="3.5" y2="-3" width="0.1016" layer="51"/>
-<wire x1="3.5" y1="-3" x2="3" y2="-3.5" width="0.1016" layer="51"/>
-<wire x1="3" y1="-3.5" x2="-3" y2="-3.5" width="0.1016" layer="51"/>
-<wire x1="-3" y1="-3.5" x2="-3.5" y2="-3" width="0.1016" layer="51"/>
-<wire x1="-3.5" y1="-3" x2="-3.5" y2="3" width="0.1016" layer="51"/>
-<wire x1="-3.5" y1="3" x2="-3" y2="3.5" width="0.1016" layer="51"/>
-<wire x1="-3.5916" y1="2.84" x2="-3.06" y2="2.84" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="2.84" x2="-3.06" y2="2.66" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="2.66" x2="-3.5916" y2="2.66" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="2.66" x2="-3.5916" y2="2.84" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="2.75" x2="-3.11" y2="2.75" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="2.845" x2="-3.055" y2="2.845" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="2.845" x2="-3.055" y2="2.655" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="2.655" x2="-3.60295" y2="2.655" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="2.655" x2="-3.60295" y2="2.845" width="0.1016" layer="29"/>
-<wire x1="-3.55295" y1="2.75" x2="-3.105" y2="2.75" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="2.34" x2="-3.06" y2="2.34" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="2.34" x2="-3.06" y2="2.16" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="2.16" x2="-3.5916" y2="2.16" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="2.16" x2="-3.5916" y2="2.34" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="2.25" x2="-3.11" y2="2.25" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="2.345" x2="-3.055" y2="2.345" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="2.345" x2="-3.055" y2="2.155" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="2.155" x2="-3.60295" y2="2.155" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="2.155" x2="-3.60295" y2="2.345" width="0.1016" layer="29"/>
-<wire x1="-3.5593" y1="2.25" x2="-3.105" y2="2.25" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="1.84" x2="-3.06" y2="1.84" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="1.84" x2="-3.06" y2="1.66" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="1.66" x2="-3.5916" y2="1.66" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="1.66" x2="-3.5916" y2="1.84" width="0.1016" layer="31"/>
-<wire x1="-3.567" y1="1.75" x2="-3.11" y2="1.75" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="1.845" x2="-3.055" y2="1.845" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="1.845" x2="-3.055" y2="1.655" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="1.655" x2="-3.60295" y2="1.655" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="1.655" x2="-3.60295" y2="1.845" width="0.1016" layer="29"/>
-<wire x1="-3.5593" y1="1.75" x2="-3.105" y2="1.75" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="1.34" x2="-3.06" y2="1.34" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="1.34" x2="-3.06" y2="1.16" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="1.16" x2="-3.5916" y2="1.16" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="1.16" x2="-3.5916" y2="1.34" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="1.25" x2="-3.11" y2="1.25" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="1.345" x2="-3.055" y2="1.345" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="1.345" x2="-3.055" y2="1.155" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="1.155" x2="-3.60295" y2="1.155" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="1.155" x2="-3.60295" y2="1.345" width="0.1016" layer="29"/>
-<wire x1="-3.55295" y1="1.25" x2="-3.105" y2="1.25" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="0.84" x2="-3.06" y2="0.84" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="0.84" x2="-3.06" y2="0.66" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="0.66" x2="-3.5916" y2="0.66" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="0.66" x2="-3.5916" y2="0.84" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="0.75" x2="-3.11" y2="0.75" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="0.845" x2="-3.055" y2="0.845" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="0.845" x2="-3.055" y2="0.655" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="0.655" x2="-3.60295" y2="0.655" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="0.655" x2="-3.60295" y2="0.845" width="0.1016" layer="29"/>
-<wire x1="-3.55295" y1="0.75" x2="-3.105" y2="0.75" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="0.34" x2="-3.06" y2="0.34" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="0.34" x2="-3.06" y2="0.16" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="0.16" x2="-3.5916" y2="0.16" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="0.16" x2="-3.5916" y2="0.34" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="0.25" x2="-3.11" y2="0.25" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="0.345" x2="-3.055" y2="0.345" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="0.345" x2="-3.055" y2="0.155" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="0.155" x2="-3.60295" y2="0.155" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="0.155" x2="-3.60295" y2="0.345" width="0.1016" layer="29"/>
-<wire x1="-3.5593" y1="0.25" x2="-3.105" y2="0.25" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="-0.16" x2="-3.06" y2="-0.16" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-0.16" x2="-3.06" y2="-0.34" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-0.34" x2="-3.5916" y2="-0.34" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="-0.34" x2="-3.5916" y2="-0.16" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="-0.25" x2="-3.11" y2="-0.25" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="-0.155" x2="-3.055" y2="-0.155" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-0.155" x2="-3.055" y2="-0.345" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-0.345" x2="-3.60295" y2="-0.345" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="-0.345" x2="-3.60295" y2="-0.155" width="0.1016" layer="29"/>
-<wire x1="-3.5466" y1="-0.25" x2="-3.105" y2="-0.25" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="-0.66" x2="-3.06" y2="-0.66" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-0.66" x2="-3.06" y2="-0.84" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-0.84" x2="-3.5916" y2="-0.84" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="-0.84" x2="-3.5916" y2="-0.66" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="-0.75" x2="-3.11" y2="-0.75" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="-0.655" x2="-3.055" y2="-0.655" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-0.655" x2="-3.055" y2="-0.845" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-0.845" x2="-3.60295" y2="-0.845" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="-0.845" x2="-3.60295" y2="-0.655" width="0.1016" layer="29"/>
-<wire x1="-3.55295" y1="-0.75" x2="-3.105" y2="-0.75" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="-1.16" x2="-3.06" y2="-1.16" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-1.16" x2="-3.06" y2="-1.34" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-1.34" x2="-3.5916" y2="-1.34" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="-1.34" x2="-3.5916" y2="-1.16" width="0.1016" layer="31"/>
-<wire x1="-3.567" y1="-1.25" x2="-3.11" y2="-1.25" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="-1.155" x2="-3.055" y2="-1.155" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-1.155" x2="-3.055" y2="-1.345" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-1.345" x2="-3.60295" y2="-1.345" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="-1.345" x2="-3.60295" y2="-1.155" width="0.1016" layer="29"/>
-<wire x1="-3.54025" y1="-1.25" x2="-3.105" y2="-1.25" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="-1.66" x2="-3.06" y2="-1.66" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-1.66" x2="-3.06" y2="-1.84" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-1.84" x2="-3.5916" y2="-1.84" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="-1.84" x2="-3.5916" y2="-1.66" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="-1.75" x2="-3.11" y2="-1.75" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="-1.655" x2="-3.055" y2="-1.655" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-1.655" x2="-3.055" y2="-1.845" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-1.845" x2="-3.60295" y2="-1.845" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="-1.845" x2="-3.60295" y2="-1.655" width="0.1016" layer="29"/>
-<wire x1="-3.5466" y1="-1.75" x2="-3.105" y2="-1.75" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="-2.16" x2="-3.06" y2="-2.16" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-2.16" x2="-3.06" y2="-2.34" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-2.34" x2="-3.5916" y2="-2.34" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="-2.34" x2="-3.5916" y2="-2.16" width="0.1016" layer="31"/>
-<wire x1="-3.5416" y1="-2.25" x2="-3.11" y2="-2.25" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="-2.155" x2="-3.055" y2="-2.155" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-2.155" x2="-3.055" y2="-2.345" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-2.345" x2="-3.60295" y2="-2.345" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="-2.345" x2="-3.60295" y2="-2.155" width="0.1016" layer="29"/>
-<wire x1="-3.56565" y1="-2.25" x2="-3.105" y2="-2.25" width="0.1016" layer="29"/>
-<wire x1="-3.5916" y1="-2.66" x2="-3.06" y2="-2.66" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-2.66" x2="-3.06" y2="-2.84" width="0.1016" layer="31"/>
-<wire x1="-3.06" y1="-2.84" x2="-3.5916" y2="-2.84" width="0.1016" layer="31"/>
-<wire x1="-3.5916" y1="-2.84" x2="-3.5916" y2="-2.66" width="0.1016" layer="31"/>
-<wire x1="-3.567" y1="-2.75" x2="-3.11" y2="-2.75" width="0.1016" layer="31"/>
-<wire x1="-3.60295" y1="-2.655" x2="-3.055" y2="-2.655" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-2.655" x2="-3.055" y2="-2.845" width="0.1016" layer="29"/>
-<wire x1="-3.055" y1="-2.845" x2="-3.60295" y2="-2.845" width="0.1016" layer="29"/>
-<wire x1="-3.60295" y1="-2.845" x2="-3.60295" y2="-2.655" width="0.1016" layer="29"/>
-<wire x1="-3.55295" y1="-2.75" x2="-3.105" y2="-2.75" width="0.1016" layer="29"/>
-<wire x1="-2.84" y1="-3.5916" x2="-2.84" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-2.84" y1="-3.06" x2="-2.66" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-2.66" y1="-3.06" x2="-2.66" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-2.66" y1="-3.5916" x2="-2.84" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-2.75" y1="-3.5416" x2="-2.75" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="-2.845" y1="-3.60295" x2="-2.845" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-2.845" y1="-3.055" x2="-2.655" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-2.655" y1="-3.055" x2="-2.655" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.655" y1="-3.60295" x2="-2.845" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.75" y1="-3.5593" x2="-2.75" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="-2.34" y1="-3.5916" x2="-2.34" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-2.34" y1="-3.06" x2="-2.16" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-2.16" y1="-3.06" x2="-2.16" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-2.16" y1="-3.5916" x2="-2.34" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-2.25" y1="-3.5416" x2="-2.25" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="-2.345" y1="-3.60295" x2="-2.345" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-2.345" y1="-3.055" x2="-2.155" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-2.155" y1="-3.055" x2="-2.155" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.155" y1="-3.60295" x2="-2.345" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.25" y1="-3.5593" x2="-2.25" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="-1.84" y1="-3.5916" x2="-1.84" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-1.84" y1="-3.06" x2="-1.66" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-1.66" y1="-3.06" x2="-1.66" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.66" y1="-3.5916" x2="-1.84" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.75" y1="-3.5416" x2="-1.75" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="-1.845" y1="-3.60295" x2="-1.845" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-1.845" y1="-3.055" x2="-1.655" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-1.655" y1="-3.055" x2="-1.655" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.655" y1="-3.60295" x2="-1.845" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.75" y1="-3.5593" x2="-1.75" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="-1.34" y1="-3.5916" x2="-1.34" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-1.34" y1="-3.06" x2="-1.16" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-1.16" y1="-3.06" x2="-1.16" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.16" y1="-3.5916" x2="-1.34" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.25" y1="-3.5416" x2="-1.25" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="-1.345" y1="-3.60295" x2="-1.345" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-1.345" y1="-3.055" x2="-1.155" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-1.155" y1="-3.055" x2="-1.155" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.155" y1="-3.60295" x2="-1.345" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.25" y1="-3.55295" x2="-1.25" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="-0.84" y1="-3.5916" x2="-0.84" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-0.84" y1="-3.06" x2="-0.66" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-0.66" y1="-3.06" x2="-0.66" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.66" y1="-3.5916" x2="-0.84" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.75" y1="-3.567" x2="-0.75" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="-0.845" y1="-3.60295" x2="-0.845" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-0.845" y1="-3.055" x2="-0.655" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-0.655" y1="-3.055" x2="-0.655" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.655" y1="-3.60295" x2="-0.845" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.75" y1="-3.56565" x2="-0.75" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="-0.34" y1="-3.5916" x2="-0.34" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-0.34" y1="-3.06" x2="-0.16" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="-0.16" y1="-3.06" x2="-0.16" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.16" y1="-3.5916" x2="-0.34" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.25" y1="-3.5416" x2="-0.25" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="-0.345" y1="-3.60295" x2="-0.345" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-0.345" y1="-3.055" x2="-0.155" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="-0.155" y1="-3.055" x2="-0.155" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.155" y1="-3.60295" x2="-0.345" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.25" y1="-3.55295" x2="-0.25" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="0.16" y1="-3.5916" x2="0.16" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="0.16" y1="-3.06" x2="0.34" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="0.34" y1="-3.06" x2="0.34" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="0.34" y1="-3.5916" x2="0.16" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="0.25" y1="-3.5416" x2="0.25" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="0.155" y1="-3.60295" x2="0.155" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="0.155" y1="-3.055" x2="0.345" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="0.345" y1="-3.055" x2="0.345" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="0.345" y1="-3.60295" x2="0.155" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="0.25" y1="-3.5593" x2="0.25" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="0.66" y1="-3.5916" x2="0.66" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="0.66" y1="-3.06" x2="0.84" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="0.84" y1="-3.06" x2="0.84" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="0.84" y1="-3.5916" x2="0.66" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="0.75" y1="-3.5416" x2="0.75" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="0.655" y1="-3.60295" x2="0.655" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="0.655" y1="-3.055" x2="0.845" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="0.845" y1="-3.055" x2="0.845" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="0.845" y1="-3.60295" x2="0.655" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="0.75" y1="-3.572" x2="0.75" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="1.16" y1="-3.5916" x2="1.16" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="1.16" y1="-3.06" x2="1.34" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="1.34" y1="-3.06" x2="1.34" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="1.34" y1="-3.5916" x2="1.16" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="1.25" y1="-3.5416" x2="1.25" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="1.155" y1="-3.60295" x2="1.155" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="1.155" y1="-3.055" x2="1.345" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="1.345" y1="-3.055" x2="1.345" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="1.345" y1="-3.60295" x2="1.155" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="1.25" y1="-3.56565" x2="1.25" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="1.66" y1="-3.5916" x2="1.66" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="1.66" y1="-3.06" x2="1.84" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="1.84" y1="-3.06" x2="1.84" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="1.84" y1="-3.5916" x2="1.66" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="1.75" y1="-3.5416" x2="1.75" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="1.655" y1="-3.60295" x2="1.655" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="1.655" y1="-3.055" x2="1.845" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="1.845" y1="-3.055" x2="1.845" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="1.845" y1="-3.60295" x2="1.655" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="1.75" y1="-3.56565" x2="1.75" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="2.16" y1="-3.5916" x2="2.16" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="2.16" y1="-3.06" x2="2.34" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="2.34" y1="-3.06" x2="2.34" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="2.34" y1="-3.5916" x2="2.16" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="2.25" y1="-3.5416" x2="2.25" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="2.155" y1="-3.60295" x2="2.155" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="2.155" y1="-3.055" x2="2.345" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="2.345" y1="-3.055" x2="2.345" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="2.345" y1="-3.60295" x2="2.155" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="2.25" y1="-3.5466" x2="2.25" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="2.66" y1="-3.5916" x2="2.66" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="2.66" y1="-3.06" x2="2.84" y2="-3.06" width="0.1016" layer="31"/>
-<wire x1="2.84" y1="-3.06" x2="2.84" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="2.84" y1="-3.5916" x2="2.66" y2="-3.5916" width="0.1016" layer="31"/>
-<wire x1="2.75" y1="-3.5416" x2="2.75" y2="-3.11" width="0.1016" layer="31"/>
-<wire x1="2.655" y1="-3.60295" x2="2.655" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="2.655" y1="-3.055" x2="2.845" y2="-3.055" width="0.1016" layer="29"/>
-<wire x1="2.845" y1="-3.055" x2="2.845" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="2.845" y1="-3.60295" x2="2.655" y2="-3.60295" width="0.1016" layer="29"/>
-<wire x1="2.75" y1="-3.54025" x2="2.75" y2="-3.105" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="-2.84" x2="3.06" y2="-2.84" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-2.84" x2="3.06" y2="-2.66" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-2.66" x2="3.5916" y2="-2.66" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="-2.66" x2="3.5916" y2="-2.84" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="-2.75" x2="3.11" y2="-2.75" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="-2.845" x2="3.055" y2="-2.845" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-2.845" x2="3.055" y2="-2.655" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-2.655" x2="3.60295" y2="-2.655" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="-2.655" x2="3.60295" y2="-2.845" width="0.1016" layer="29"/>
-<wire x1="3.5466" y1="-2.75" x2="3.105" y2="-2.75" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="-2.34" x2="3.06" y2="-2.34" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-2.34" x2="3.06" y2="-2.16" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-2.16" x2="3.5916" y2="-2.16" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="-2.16" x2="3.5916" y2="-2.34" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="-2.25" x2="3.11" y2="-2.25" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="-2.345" x2="3.055" y2="-2.345" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-2.345" x2="3.055" y2="-2.155" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-2.155" x2="3.60295" y2="-2.155" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="-2.155" x2="3.60295" y2="-2.345" width="0.1016" layer="29"/>
-<wire x1="3.55295" y1="-2.25" x2="3.105" y2="-2.25" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="-1.84" x2="3.06" y2="-1.84" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-1.84" x2="3.06" y2="-1.66" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-1.66" x2="3.5916" y2="-1.66" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="-1.66" x2="3.5916" y2="-1.84" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="-1.75" x2="3.11" y2="-1.75" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="-1.845" x2="3.055" y2="-1.845" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-1.845" x2="3.055" y2="-1.655" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-1.655" x2="3.60295" y2="-1.655" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="-1.655" x2="3.60295" y2="-1.845" width="0.1016" layer="29"/>
-<wire x1="3.5466" y1="-1.75" x2="3.105" y2="-1.75" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="-1.34" x2="3.06" y2="-1.34" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-1.34" x2="3.06" y2="-1.16" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-1.16" x2="3.5916" y2="-1.16" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="-1.16" x2="3.5916" y2="-1.34" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="-1.25" x2="3.11" y2="-1.25" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="-1.35135" x2="3.055" y2="-1.345" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-1.345" x2="3.055" y2="-1.155" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-1.155" x2="3.60295" y2="-1.16135" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="-1.16135" x2="3.60295" y2="-1.35135" width="0.1016" layer="29"/>
-<wire x1="3.55295" y1="-1.25" x2="3.105" y2="-1.25" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="-0.84" x2="3.06" y2="-0.84" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-0.84" x2="3.06" y2="-0.66" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-0.66" x2="3.5916" y2="-0.66" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="-0.66" x2="3.5916" y2="-0.84" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="-0.75" x2="3.11" y2="-0.75" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="-0.845" x2="3.055" y2="-0.845" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-0.845" x2="3.055" y2="-0.655" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-0.655" x2="3.60295" y2="-0.655" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="-0.655" x2="3.60295" y2="-0.845" width="0.1016" layer="29"/>
-<wire x1="3.55295" y1="-0.75" x2="3.105" y2="-0.75" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="-0.34" x2="3.06" y2="-0.34" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-0.34" x2="3.06" y2="-0.16" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="-0.16" x2="3.5916" y2="-0.16" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="-0.16" x2="3.5916" y2="-0.34" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="-0.25" x2="3.11" y2="-0.25" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="-0.345" x2="3.055" y2="-0.345" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-0.345" x2="3.055" y2="-0.155" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="-0.155" x2="3.60295" y2="-0.155" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="-0.155" x2="3.60295" y2="-0.345" width="0.1016" layer="29"/>
-<wire x1="3.55295" y1="-0.25" x2="3.105" y2="-0.25" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="0.16" x2="3.06" y2="0.16" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="0.16" x2="3.06" y2="0.34" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="0.34" x2="3.5916" y2="0.34" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="0.34" x2="3.5916" y2="0.16" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="0.25" x2="3.11" y2="0.25" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="0.155" x2="3.055" y2="0.155" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="0.155" x2="3.055" y2="0.345" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="0.345" x2="3.60295" y2="0.345" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="0.345" x2="3.60295" y2="0.155" width="0.1016" layer="29"/>
-<wire x1="3.5593" y1="0.25" x2="3.105" y2="0.25" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="0.66" x2="3.06" y2="0.66" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="0.66" x2="3.06" y2="0.84" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="0.84" x2="3.5916" y2="0.84" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="0.84" x2="3.5916" y2="0.66" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="0.75" x2="3.11" y2="0.75" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="0.655" x2="3.055" y2="0.655" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="0.655" x2="3.055" y2="0.845" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="0.845" x2="3.60295" y2="0.845" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="0.845" x2="3.60295" y2="0.655" width="0.1016" layer="29"/>
-<wire x1="3.5593" y1="0.75" x2="3.105" y2="0.75" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="1.16" x2="3.06" y2="1.16" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="1.16" x2="3.06" y2="1.34" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="1.34" x2="3.5916" y2="1.34" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="1.34" x2="3.5916" y2="1.16" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="1.25" x2="3.11" y2="1.25" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="1.155" x2="3.055" y2="1.155" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="1.155" x2="3.055" y2="1.345" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="1.345" x2="3.60295" y2="1.345" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="1.345" x2="3.60295" y2="1.155" width="0.1016" layer="29"/>
-<wire x1="3.55295" y1="1.25" x2="3.105" y2="1.25" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="1.66" x2="3.06" y2="1.66" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="1.66" x2="3.06" y2="1.84" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="1.84" x2="3.5916" y2="1.84" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="1.84" x2="3.5916" y2="1.66" width="0.1016" layer="31"/>
-<wire x1="3.567" y1="1.75" x2="3.11" y2="1.75" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="1.655" x2="3.055" y2="1.655" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="1.655" x2="3.055" y2="1.845" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="1.845" x2="3.60295" y2="1.845" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="1.845" x2="3.60295" y2="1.655" width="0.1016" layer="29"/>
-<wire x1="3.55295" y1="1.75" x2="3.105" y2="1.75" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="2.16" x2="3.06" y2="2.16" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="2.16" x2="3.06" y2="2.34" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="2.34" x2="3.5916" y2="2.34" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="2.34" x2="3.5916" y2="2.16" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="2.25" x2="3.11" y2="2.25" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="2.155" x2="3.055" y2="2.155" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="2.155" x2="3.055" y2="2.345" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="2.345" x2="3.60295" y2="2.345" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="2.345" x2="3.60295" y2="2.155" width="0.1016" layer="29"/>
-<wire x1="3.55295" y1="2.25" x2="3.105" y2="2.25" width="0.1016" layer="29"/>
-<wire x1="3.5916" y1="2.66" x2="3.06" y2="2.66" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="2.66" x2="3.06" y2="2.84" width="0.1016" layer="31"/>
-<wire x1="3.06" y1="2.84" x2="3.5916" y2="2.84" width="0.1016" layer="31"/>
-<wire x1="3.5916" y1="2.84" x2="3.5916" y2="2.66" width="0.1016" layer="31"/>
-<wire x1="3.5416" y1="2.75" x2="3.11" y2="2.75" width="0.1016" layer="31"/>
-<wire x1="3.60295" y1="2.655" x2="3.055" y2="2.655" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="2.655" x2="3.055" y2="2.845" width="0.1016" layer="29"/>
-<wire x1="3.055" y1="2.845" x2="3.60295" y2="2.845" width="0.1016" layer="29"/>
-<wire x1="3.60295" y1="2.845" x2="3.60295" y2="2.655" width="0.1016" layer="29"/>
-<wire x1="3.5466" y1="2.75" x2="3.105" y2="2.75" width="0.1016" layer="29"/>
-<wire x1="2.84" y1="3.5916" x2="2.84" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="2.84" y1="3.06" x2="2.66" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="2.66" y1="3.06" x2="2.66" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="2.66" y1="3.5916" x2="2.84" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="2.75" y1="3.5416" x2="2.75" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="2.845" y1="3.60295" x2="2.845" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="2.845" y1="3.055" x2="2.655" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="2.655" y1="3.055" x2="2.655" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="2.655" y1="3.60295" x2="2.845" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="2.75" y1="3.55295" x2="2.75" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="2.34" y1="3.5916" x2="2.34" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="2.34" y1="3.06" x2="2.16" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="2.16" y1="3.06" x2="2.16" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="2.16" y1="3.5916" x2="2.34" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="2.25" y1="3.5162" x2="2.25" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="2.345" y1="3.60295" x2="2.345" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="2.345" y1="3.055" x2="2.155" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="2.155" y1="3.055" x2="2.155" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="2.155" y1="3.60295" x2="2.345" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="2.25" y1="3.56565" x2="2.25" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="1.84" y1="3.5916" x2="1.84" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="1.84" y1="3.06" x2="1.66" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="1.66" y1="3.06" x2="1.66" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="1.66" y1="3.5916" x2="1.84" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="1.75" y1="3.5416" x2="1.75" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="1.845" y1="3.60295" x2="1.845" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="1.845" y1="3.055" x2="1.655" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="1.655" y1="3.055" x2="1.655" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="1.655" y1="3.60295" x2="1.845" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="1.75" y1="3.55295" x2="1.75" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="1.34" y1="3.5916" x2="1.34" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="1.34" y1="3.06" x2="1.16" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="1.16" y1="3.06" x2="1.16" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="1.16" y1="3.5916" x2="1.34" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="1.25" y1="3.5416" x2="1.25" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="1.345" y1="3.60295" x2="1.345" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="1.345" y1="3.055" x2="1.155" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="1.155" y1="3.055" x2="1.155" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="1.155" y1="3.60295" x2="1.345" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="1.25" y1="3.5466" x2="1.25" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="0.84" y1="3.5916" x2="0.84" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="0.84" y1="3.06" x2="0.66" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="0.66" y1="3.06" x2="0.66" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="0.66" y1="3.5916" x2="0.84" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="0.75" y1="3.5416" x2="0.75" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="0.845" y1="3.60295" x2="0.845" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="0.845" y1="3.055" x2="0.655" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="0.655" y1="3.055" x2="0.655" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="0.655" y1="3.60295" x2="0.845" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="0.75" y1="3.54025" x2="0.75" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="0.34" y1="3.5916" x2="0.34" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="0.34" y1="3.06" x2="0.16" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="0.16" y1="3.06" x2="0.16" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="0.16" y1="3.5916" x2="0.34" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="0.25" y1="3.5416" x2="0.25" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="0.345" y1="3.60295" x2="0.345" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="0.345" y1="3.055" x2="0.155" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="0.155" y1="3.055" x2="0.155" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="0.155" y1="3.60295" x2="0.345" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="0.25" y1="3.5466" x2="0.25" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="-0.16" y1="3.5916" x2="-0.16" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-0.16" y1="3.06" x2="-0.34" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-0.34" y1="3.06" x2="-0.34" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.34" y1="3.5916" x2="-0.16" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.25" y1="3.567" x2="-0.25" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="-0.155" y1="3.60295" x2="-0.155" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-0.155" y1="3.055" x2="-0.345" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-0.345" y1="3.055" x2="-0.345" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.345" y1="3.60295" x2="-0.155" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.25" y1="3.5466" x2="-0.25" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="-0.66" y1="3.5916" x2="-0.66" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-0.66" y1="3.06" x2="-0.84" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-0.84" y1="3.06" x2="-0.84" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.84" y1="3.5916" x2="-0.66" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-0.75" y1="3.567" x2="-0.75" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="-0.655" y1="3.60295" x2="-0.655" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-0.655" y1="3.055" x2="-0.845" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-0.845" y1="3.055" x2="-0.845" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.845" y1="3.60295" x2="-0.655" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-0.75" y1="3.5466" x2="-0.75" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="-1.16" y1="3.5916" x2="-1.16" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-1.16" y1="3.06" x2="-1.34" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-1.34" y1="3.06" x2="-1.34" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.34" y1="3.5916" x2="-1.16" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.25" y1="3.5416" x2="-1.25" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="-1.155" y1="3.60295" x2="-1.155" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-1.155" y1="3.055" x2="-1.345" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-1.345" y1="3.055" x2="-1.345" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.345" y1="3.60295" x2="-1.155" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.25" y1="3.5593" x2="-1.25" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="-1.66" y1="3.5916" x2="-1.66" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-1.66" y1="3.06" x2="-1.84" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-1.84" y1="3.06" x2="-1.84" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.84" y1="3.5916" x2="-1.66" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-1.75" y1="3.567" x2="-1.75" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="-1.655" y1="3.60295" x2="-1.655" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-1.655" y1="3.055" x2="-1.845" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-1.845" y1="3.055" x2="-1.845" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.845" y1="3.60295" x2="-1.655" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-1.75" y1="3.572" x2="-1.75" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="-2.16" y1="3.5916" x2="-2.16" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-2.16" y1="3.06" x2="-2.34" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-2.34" y1="3.06" x2="-2.34" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-2.34" y1="3.5916" x2="-2.16" y2="3.5916" width="0.1016" layer="31"/>
-<wire x1="-2.25" y1="3.5416" x2="-2.25" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="-2.155" y1="3.60295" x2="-2.155" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-2.155" y1="3.055" x2="-2.345" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-2.345" y1="3.055" x2="-2.345" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.345" y1="3.60295" x2="-2.155" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.25" y1="3.5593" x2="-2.25" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="-2.66" y1="3.5941" x2="-2.66" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-2.66" y1="3.06" x2="-2.84" y2="3.06" width="0.1016" layer="31"/>
-<wire x1="-2.84" y1="3.06" x2="-2.84" y2="3.5941" width="0.1016" layer="31"/>
-<wire x1="-2.84" y1="3.5941" x2="-2.75" y2="3.5941" width="0.1016" layer="31"/>
-<wire x1="-2.75" y1="3.5941" x2="-2.66" y2="3.5941" width="0.1016" layer="31"/>
-<wire x1="-2.75" y1="3.5941" x2="-2.75" y2="3.11" width="0.1016" layer="31"/>
-<wire x1="-2.655" y1="3.60295" x2="-2.655" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-2.655" y1="3.055" x2="-2.845" y2="3.055" width="0.1016" layer="29"/>
-<wire x1="-2.845" y1="3.055" x2="-2.845" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.845" y1="3.60295" x2="-2.655" y2="3.60295" width="0.1016" layer="29"/>
-<wire x1="-2.75" y1="3.572" x2="-2.75" y2="3.105" width="0.1016" layer="29"/>
-<wire x1="-2.667" y1="1.27" x2="-2.667" y2="2.667" width="0.127" layer="25"/>
-<wire x1="-2.667" y1="2.667" x2="-1.27" y2="2.667" width="0.127" layer="25"/>
-<rectangle x1="-3.45" y1="2.535" x2="-3.22" y2="2.965" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="2.035" x2="-3.22" y2="2.465" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="1.535" x2="-3.22" y2="1.965" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="1.035" x2="-3.22" y2="1.465" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="0.535" x2="-3.22" y2="0.965" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="0.035" x2="-3.22" y2="0.465" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="-0.465" x2="-3.22" y2="-0.035" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="-0.965" x2="-3.22" y2="-0.535" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="-1.465" x2="-3.22" y2="-1.035" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="-1.965" x2="-3.22" y2="-1.535" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="-2.465" x2="-3.22" y2="-2.035" layer="51" rot="R270"/>
-<rectangle x1="-3.45" y1="-2.965" x2="-3.22" y2="-2.535" layer="51" rot="R270"/>
-<rectangle x1="-2.865" y1="-3.55" x2="-2.635" y2="-3.12" layer="51"/>
-<rectangle x1="-2.365" y1="-3.55" x2="-2.135" y2="-3.12" layer="51"/>
-<rectangle x1="-1.865" y1="-3.55" x2="-1.635" y2="-3.12" layer="51"/>
-<rectangle x1="-1.365" y1="-3.55" x2="-1.135" y2="-3.12" layer="51"/>
-<rectangle x1="-0.865" y1="-3.55" x2="-0.635" y2="-3.12" layer="51"/>
-<rectangle x1="-0.365" y1="-3.55" x2="-0.135" y2="-3.12" layer="51"/>
-<rectangle x1="0.135" y1="-3.55" x2="0.365" y2="-3.12" layer="51"/>
-<rectangle x1="0.635" y1="-3.55" x2="0.865" y2="-3.12" layer="51"/>
-<rectangle x1="1.135" y1="-3.55" x2="1.365" y2="-3.12" layer="51"/>
-<rectangle x1="1.635" y1="-3.55" x2="1.865" y2="-3.12" layer="51"/>
-<rectangle x1="2.135" y1="-3.55" x2="2.365" y2="-3.12" layer="51"/>
-<rectangle x1="2.635" y1="-3.55" x2="2.865" y2="-3.12" layer="51"/>
-<rectangle x1="3.22" y1="-2.965" x2="3.45" y2="-2.535" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="-2.465" x2="3.45" y2="-2.035" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="-1.965" x2="3.45" y2="-1.535" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="-1.465" x2="3.45" y2="-1.035" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="-0.965" x2="3.45" y2="-0.535" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="-0.465" x2="3.45" y2="-0.035" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="0.035" x2="3.45" y2="0.465" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="0.535" x2="3.45" y2="0.965" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="1.035" x2="3.45" y2="1.465" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="1.535" x2="3.45" y2="1.965" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="2.035" x2="3.45" y2="2.465" layer="51" rot="R90"/>
-<rectangle x1="3.22" y1="2.535" x2="3.45" y2="2.965" layer="51" rot="R90"/>
-<rectangle x1="2.635" y1="3.12" x2="2.865" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="2.135" y1="3.12" x2="2.365" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="1.635" y1="3.12" x2="1.865" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="1.135" y1="3.12" x2="1.365" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="0.635" y1="3.12" x2="0.865" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="0.135" y1="3.12" x2="0.365" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="-0.365" y1="3.12" x2="-0.135" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="-0.865" y1="3.12" x2="-0.635" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="-1.365" y1="3.12" x2="-1.135" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="-1.865" y1="3.12" x2="-1.635" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="-2.365" y1="3.12" x2="-2.135" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="-2.865" y1="3.12" x2="-2.635" y2="3.55" layer="51" rot="R180"/>
-<rectangle x1="-2.286" y1="-2.286" x2="2.286" y2="2.286" layer="29"/>
-<rectangle x1="0.6985" y1="0.762" x2="1.8415" y2="1.905" layer="31"/>
-<rectangle x1="-1.8415" y1="-1.905" x2="-0.6985" y2="-0.762" layer="31"/>
-<rectangle x1="-1.905" y1="0.6985" x2="-0.762" y2="1.8415" layer="31"/>
-<rectangle x1="0.635" y1="-1.8415" x2="1.778" y2="-0.6985" layer="31"/>
-<smd name="1" x="-3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="2" x="-3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="3" x="-3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="4" x="-3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="5" x="-3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="6" x="-3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="7" x="-3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="8" x="-3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="9" x="-3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="10" x="-3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="11" x="-3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="12" x="-3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="13" x="-2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="14" x="-2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="15" x="-1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="16" x="-1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="17" x="-0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="18" x="-0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="19" x="0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="20" x="0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="21" x="1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="22" x="1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="23" x="2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="24" x="2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="25" x="3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="26" x="3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="27" x="3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="28" x="3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="29" x="3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="30" x="3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="31" x="3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="32" x="3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="33" x="3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="34" x="3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="35" x="3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="36" x="3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="37" x="2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="38" x="2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="39" x="1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="40" x="1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="41" x="0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="42" x="0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="43" x="-0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="44" x="-0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="45" x="-1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="46" x="-1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="47" x="-2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="48" x="-2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="EXP" x="0" y="0" dx="4.572" dy="4.572" layer="1" roundness="5" stop="no" cream="no"/>
-<text x="-3" y="4" size="1.27" layer="25">&gt;NAME</text>
-<text x="-3" y="-5" size="1.27" layer="27">&gt;VALUE</text>
-</package>
-</packages>
-</library>
-<library name="SparkFun-LED" urn="urn:adsk.eagle:library:529">
-<description>&lt;h3&gt;SparkFun LEDs&lt;/h3&gt;
-This library contains discrete LEDs for illumination or indication, but no displays.
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
-<packages>
-<package name="LED-0603" urn="urn:adsk.eagle:footprint:39307/1" library_version="1">
-<description>&lt;B&gt;LED 0603 SMT&lt;/B&gt;&lt;p&gt;
-0603, surface mount.
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch:0.075inch &lt;/li&gt;
-&lt;li&gt;Area: 0.06" x 0.03"&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED - BLUE&lt;/li&gt;</description>
-<smd name="C" x="0.877" y="0" dx="1" dy="1" layer="1" roundness="30" rot="R270"/>
-<smd name="A" x="-0.877" y="0" dx="1" dy="1" layer="1" roundness="30" rot="R270"/>
-<text x="0" y="0.635" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.635" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<wire x1="1.5875" y1="0.47625" x2="1.5875" y2="-0.47625" width="0.127" layer="21"/>
-<wire x1="0.15875" y1="0.47625" x2="0.15875" y2="0" width="0.127" layer="51"/>
-<wire x1="0.15875" y1="0" x2="0.15875" y2="-0.47625" width="0.127" layer="51"/>
-<wire x1="0.15875" y1="0" x2="-0.15875" y2="0.3175" width="0.127" layer="51"/>
-<wire x1="0.15875" y1="0" x2="-0.15875" y2="-0.3175" width="0.127" layer="51"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="LED-0603" urn="urn:adsk.eagle:package:39354/1" type="box" library_version="1">
-<description>LED 0603 SMT
-0603, surface mount.
-Specifications:
-Pin count: 2
-Pin pitch:0.075inch 
-Area: 0.06" x 0.03"
-
-Example device(s):
-LED - BLUE</description>
-<packageinstances>
-<packageinstance name="LED-0603"/>
-</packageinstances>
-</package3d>
-</packages3d>
-</library>
-<library name="Seeed-Capacitor" urn="urn:adsk.eagle:library:464">
-<packages>
-<package name="C0402" urn="urn:adsk.eagle:footprint:32368/1" library_version="1">
-<description>&lt;b&gt;0402&lt;b&gt;&lt;p&gt;</description>
-<smd name="1" x="0" y="0.4625" dx="0.5" dy="0.5" layer="1" roundness="50" rot="R270"/>
-<smd name="2" x="0" y="-0.4625" dx="0.5" dy="0.5" layer="1" roundness="50" rot="R270"/>
-<text x="0.635" y="1.27" size="0.889" layer="25" ratio="11" rot="R270">&gt;NAME</text>
-<text x="-1.524" y="1.397" size="0.635" layer="27" font="vector" ratio="10" rot="R270">&gt;VALUE</text>
-<polygon width="0.0254" layer="51">
-<vertex x="0.254" y="0.508"/>
-<vertex x="0.254" y="-0.508"/>
-<vertex x="-0.254" y="-0.508"/>
-<vertex x="-0.254" y="0.508"/>
-</polygon>
-<wire x1="0.3945" y1="-0.712" x2="0.2675" y2="-0.839" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.2675" y1="-0.839" x2="-0.2675" y2="-0.839" width="0.0762" layer="21"/>
-<wire x1="-0.2675" y1="-0.839" x2="-0.3945" y2="-0.712" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.3945" y1="-0.712" x2="-0.3945" y2="0.712" width="0.0762" layer="21"/>
-<wire x1="-0.3945" y1="0.712" x2="-0.2675" y2="0.839" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.2675" y1="0.839" x2="0.2675" y2="0.839" width="0.0762" layer="21"/>
-<wire x1="0.2675" y1="0.839" x2="0.3945" y2="0.712" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.3945" y1="0.712" x2="0.3945" y2="-0.712" width="0.0762" layer="21"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="C0402" urn="urn:adsk.eagle:package:32379/1" type="box" library_version="1">
-<description>0402</description>
-<packageinstances>
-<packageinstance name="C0402"/>
-</packageinstances>
-</package3d>
-</packages3d>
-</library>
-<library name="Seeed-Inductor" urn="urn:adsk.eagle:library:471">
-<packages>
-<package name="L0402" urn="urn:adsk.eagle:footprint:32712/1" library_version="1">
-<smd name="1" x="-0.4625" y="0" dx="0.5" dy="0.5" layer="1" roundness="50"/>
-<smd name="2" x="0.4625" y="0" dx="0.5" dy="0.5" layer="1" roundness="50"/>
-<text x="-1.27" y="0.635" size="0.889" layer="25" ratio="11">&gt;NAME</text>
-<text x="-1.27" y="-1.524" size="0.889" layer="27" font="vector" ratio="11">&gt;VALUE</text>
-<wire x1="0.712" y1="0.3945" x2="0.839" y2="0.2675" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.839" y1="0.2675" x2="0.839" y2="-0.2675" width="0.0762" layer="21"/>
-<wire x1="0.839" y1="-0.2675" x2="0.712" y2="-0.3945" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.712" y1="-0.3945" x2="-0.712" y2="-0.3945" width="0.0762" layer="21"/>
-<wire x1="-0.712" y1="-0.3945" x2="-0.839" y2="-0.2675" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.839" y1="-0.2675" x2="-0.839" y2="0.2675" width="0.0762" layer="21"/>
-<wire x1="-0.839" y1="0.2675" x2="-0.712" y2="0.3945" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.712" y1="0.3945" x2="0.712" y2="0.3945" width="0.0762" layer="21"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="L0402" urn="urn:adsk.eagle:package:32722/1" type="box" library_version="1">
-<packageinstances>
-<packageinstance name="L0402"/>
 </packageinstances>
 </package3d>
 </packages3d>
@@ -2685,6 +1691,869 @@ LED - BLUE</description>
 </package>
 </packages>
 </library>
+<library name="rc" urn="urn:adsk.eagle:library:2539423">
+<packages>
+<package name="C0603" urn="urn:adsk.eagle:footprint:2539424/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="2" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<wire x1="-1.125" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="C0402" urn="urn:adsk.eagle:footprint:2539428/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.4064" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+</package>
+<package name="R0603" urn="urn:adsk.eagle:footprint:2539436/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="2" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<wire x1="-1.125" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="LED0603" urn="urn:adsk.eagle:footprint:2539448/3" library_version="103" library_locally_modified="yes">
+<smd name="A" x="0.725" y="0" dx="0.6" dy="0.9" layer="1" rot="R180"/>
+<smd name="C" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1" rot="R180"/>
+<wire x1="1.125" y1="-0.55" x2="-0.25" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="0.55" x2="-0.25" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="-0.55" x2="-0.25" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="0" x2="0.3" y2="0.55" width="0.1" layer="51"/>
+<wire x1="0.3" y1="0.55" x2="0.3" y2="-0.55" width="0.1" layer="51"/>
+<wire x1="0.3" y1="-0.55" x2="-0.25" y2="0" width="0.1" layer="51"/>
+<wire x1="-0.25" y1="0.55" x2="-0.25" y2="-0.55" width="0.1" layer="51"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="L0402" urn="urn:adsk.eagle:footprint:5347942/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="C0603" urn="urn:adsk.eagle:package:2539457/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="C0603"/>
+</packageinstances>
+</package3d>
+<package3d name="C0402" urn="urn:adsk.eagle:package:2539461/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="C0402"/>
+</packageinstances>
+</package3d>
+<package3d name="R0603" urn="urn:adsk.eagle:package:2539454/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R0603"/>
+</packageinstances>
+</package3d>
+<package3d name="LED0603" urn="urn:adsk.eagle:package:2539471/4" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="LED0603"/>
+</packageinstances>
+</package3d>
+<package3d name="L0402" urn="urn:adsk.eagle:package:5347945/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="L0402"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+<library name="pixelblaze" urn="urn:adsk.eagle:library:35450543">
+<packages>
+<package name="PICO-D4-QFN48" urn="urn:adsk.eagle:footprint:35450557/1" library_version="3">
+<description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
+48 Quad Flat Package No Leads&lt;br&gt;
+Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
+<circle x="-3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.5" y="2.5" radius="0.4" width="0" layer="51"/>
+<wire x1="-3" y1="3.5" x2="3" y2="3.5" width="0.1016" layer="51"/>
+<wire x1="3" y1="3.5" x2="3.5" y2="3" width="0.1016" layer="51"/>
+<wire x1="3.5" y1="3" x2="3.5" y2="-3" width="0.1016" layer="51"/>
+<wire x1="3.5" y1="-3" x2="3" y2="-3.5" width="0.1016" layer="51"/>
+<wire x1="3" y1="-3.5" x2="-3" y2="-3.5" width="0.1016" layer="51"/>
+<wire x1="-3" y1="-3.5" x2="-3.5" y2="-3" width="0.1016" layer="51"/>
+<wire x1="-3.5" y1="-3" x2="-3.5" y2="3" width="0.1016" layer="51"/>
+<wire x1="-3.5" y1="3" x2="-3" y2="3.5" width="0.1016" layer="51"/>
+<wire x1="-3.5916" y1="2.84" x2="-3.06" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.84" x2="-3.06" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.66" x2="-3.5916" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="2.66" x2="-3.5916" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="2.75" x2="-3.11" y2="2.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="2.845" x2="-3.055" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.845" x2="-3.055" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.655" x2="-3.60295" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="2.655" x2="-3.60295" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="2.75" x2="-3.105" y2="2.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="2.34" x2="-3.06" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.34" x2="-3.06" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.16" x2="-3.5916" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="2.16" x2="-3.5916" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="2.25" x2="-3.11" y2="2.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="2.345" x2="-3.055" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.345" x2="-3.055" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.155" x2="-3.60295" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="2.155" x2="-3.60295" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="2.25" x2="-3.105" y2="2.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="1.84" x2="-3.06" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.84" x2="-3.06" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.66" x2="-3.5916" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="1.66" x2="-3.5916" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="1.75" x2="-3.11" y2="1.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="1.845" x2="-3.055" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.845" x2="-3.055" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.655" x2="-3.60295" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="1.655" x2="-3.60295" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="1.75" x2="-3.105" y2="1.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="1.34" x2="-3.06" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.34" x2="-3.06" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.16" x2="-3.5916" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="1.16" x2="-3.5916" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="1.25" x2="-3.11" y2="1.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="1.345" x2="-3.055" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.345" x2="-3.055" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.155" x2="-3.60295" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="1.155" x2="-3.60295" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="1.25" x2="-3.105" y2="1.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="0.84" x2="-3.06" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.84" x2="-3.06" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.66" x2="-3.5916" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="0.66" x2="-3.5916" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="0.75" x2="-3.11" y2="0.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="0.845" x2="-3.055" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.845" x2="-3.055" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.655" x2="-3.60295" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="0.655" x2="-3.60295" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="0.75" x2="-3.105" y2="0.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="0.34" x2="-3.06" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.34" x2="-3.06" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.16" x2="-3.5916" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="0.16" x2="-3.5916" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="0.25" x2="-3.11" y2="0.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="0.345" x2="-3.055" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.345" x2="-3.055" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.155" x2="-3.60295" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="0.155" x2="-3.60295" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="0.25" x2="-3.105" y2="0.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-0.16" x2="-3.06" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.16" x2="-3.06" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.34" x2="-3.5916" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-0.34" x2="-3.5916" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-0.25" x2="-3.11" y2="-0.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-0.155" x2="-3.055" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.155" x2="-3.055" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.345" x2="-3.60295" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-0.345" x2="-3.60295" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="-3.5466" y1="-0.25" x2="-3.105" y2="-0.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-0.66" x2="-3.06" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.66" x2="-3.06" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.84" x2="-3.5916" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-0.84" x2="-3.5916" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-0.75" x2="-3.11" y2="-0.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-0.655" x2="-3.055" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.655" x2="-3.055" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.845" x2="-3.60295" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-0.845" x2="-3.60295" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="-0.75" x2="-3.105" y2="-0.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-1.16" x2="-3.06" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.16" x2="-3.06" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.34" x2="-3.5916" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-1.34" x2="-3.5916" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="-1.25" x2="-3.11" y2="-1.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-1.155" x2="-3.055" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.155" x2="-3.055" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.345" x2="-3.60295" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-1.345" x2="-3.60295" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="-3.54025" y1="-1.25" x2="-3.105" y2="-1.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-1.66" x2="-3.06" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.66" x2="-3.06" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.84" x2="-3.5916" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-1.84" x2="-3.5916" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-1.75" x2="-3.11" y2="-1.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-1.655" x2="-3.055" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.655" x2="-3.055" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.845" x2="-3.60295" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-1.845" x2="-3.60295" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="-3.5466" y1="-1.75" x2="-3.105" y2="-1.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-2.16" x2="-3.06" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.16" x2="-3.06" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.34" x2="-3.5916" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-2.34" x2="-3.5916" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-2.25" x2="-3.11" y2="-2.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-2.155" x2="-3.055" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.155" x2="-3.055" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.345" x2="-3.60295" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-2.345" x2="-3.60295" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="-3.56565" y1="-2.25" x2="-3.105" y2="-2.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-2.66" x2="-3.06" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.66" x2="-3.06" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.84" x2="-3.5916" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-2.84" x2="-3.5916" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="-2.75" x2="-3.11" y2="-2.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-2.655" x2="-3.055" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.655" x2="-3.055" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.845" x2="-3.60295" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-2.845" x2="-3.60295" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="-2.75" x2="-3.105" y2="-2.75" width="0.1016" layer="29"/>
+<wire x1="-2.84" y1="-3.5916" x2="-2.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="-3.06" x2="-2.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="-3.06" x2="-2.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="-3.5916" x2="-2.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="-3.5416" x2="-2.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-2.845" y1="-3.60295" x2="-2.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="-3.055" x2="-2.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="-3.055" x2="-2.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="-3.60295" x2="-2.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.75" y1="-3.5593" x2="-2.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-2.34" y1="-3.5916" x2="-2.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="-3.06" x2="-2.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="-3.06" x2="-2.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="-3.5916" x2="-2.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.25" y1="-3.5416" x2="-2.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-2.345" y1="-3.60295" x2="-2.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="-3.055" x2="-2.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="-3.055" x2="-2.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="-3.60295" x2="-2.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.25" y1="-3.5593" x2="-2.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-1.84" y1="-3.5916" x2="-1.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="-3.06" x2="-1.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="-3.06" x2="-1.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="-3.5916" x2="-1.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.75" y1="-3.5416" x2="-1.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-1.845" y1="-3.60295" x2="-1.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="-3.055" x2="-1.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="-3.055" x2="-1.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="-3.60295" x2="-1.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.75" y1="-3.5593" x2="-1.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-1.34" y1="-3.5916" x2="-1.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="-3.06" x2="-1.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="-3.06" x2="-1.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="-3.5916" x2="-1.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.25" y1="-3.5416" x2="-1.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-1.345" y1="-3.60295" x2="-1.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="-3.055" x2="-1.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="-3.055" x2="-1.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="-3.60295" x2="-1.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.25" y1="-3.55295" x2="-1.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-0.84" y1="-3.5916" x2="-0.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="-3.06" x2="-0.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="-3.06" x2="-0.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="-3.5916" x2="-0.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.75" y1="-3.567" x2="-0.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-0.845" y1="-3.60295" x2="-0.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="-3.055" x2="-0.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="-3.055" x2="-0.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="-3.60295" x2="-0.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.75" y1="-3.56565" x2="-0.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-0.34" y1="-3.5916" x2="-0.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="-3.06" x2="-0.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="-3.06" x2="-0.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="-3.5916" x2="-0.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.25" y1="-3.5416" x2="-0.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-0.345" y1="-3.60295" x2="-0.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="-3.055" x2="-0.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="-3.055" x2="-0.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="-3.60295" x2="-0.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.25" y1="-3.55295" x2="-0.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="0.16" y1="-3.5916" x2="0.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="-3.06" x2="0.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="-3.06" x2="0.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="-3.5916" x2="0.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.25" y1="-3.5416" x2="0.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="0.155" y1="-3.60295" x2="0.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="-3.055" x2="0.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="-3.055" x2="0.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="-3.60295" x2="0.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.25" y1="-3.5593" x2="0.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="0.66" y1="-3.5916" x2="0.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="-3.06" x2="0.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="-3.06" x2="0.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="-3.5916" x2="0.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.75" y1="-3.5416" x2="0.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="0.655" y1="-3.60295" x2="0.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="-3.055" x2="0.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="-3.055" x2="0.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="-3.60295" x2="0.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.75" y1="-3.572" x2="0.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="1.16" y1="-3.5916" x2="1.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="-3.06" x2="1.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="-3.06" x2="1.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="-3.5916" x2="1.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.25" y1="-3.5416" x2="1.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="1.155" y1="-3.60295" x2="1.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="-3.055" x2="1.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="-3.055" x2="1.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="-3.60295" x2="1.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.25" y1="-3.56565" x2="1.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="1.66" y1="-3.5916" x2="1.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="-3.06" x2="1.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="-3.06" x2="1.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="-3.5916" x2="1.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.75" y1="-3.5416" x2="1.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="1.655" y1="-3.60295" x2="1.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="-3.055" x2="1.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="-3.055" x2="1.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="-3.60295" x2="1.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.75" y1="-3.56565" x2="1.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="2.16" y1="-3.5916" x2="2.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="-3.06" x2="2.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="-3.06" x2="2.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="-3.5916" x2="2.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.25" y1="-3.5416" x2="2.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="2.155" y1="-3.60295" x2="2.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="-3.055" x2="2.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="-3.055" x2="2.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="-3.60295" x2="2.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.25" y1="-3.5466" x2="2.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="2.66" y1="-3.5916" x2="2.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="-3.06" x2="2.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="-3.06" x2="2.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="-3.5916" x2="2.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.75" y1="-3.5416" x2="2.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="2.655" y1="-3.60295" x2="2.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="-3.055" x2="2.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="-3.055" x2="2.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="-3.60295" x2="2.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.75" y1="-3.54025" x2="2.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-2.84" x2="3.06" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.84" x2="3.06" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.66" x2="3.5916" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-2.66" x2="3.5916" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-2.75" x2="3.11" y2="-2.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-2.845" x2="3.055" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.845" x2="3.055" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.655" x2="3.60295" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-2.655" x2="3.60295" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="-2.75" x2="3.105" y2="-2.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-2.34" x2="3.06" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.34" x2="3.06" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.16" x2="3.5916" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-2.16" x2="3.5916" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-2.25" x2="3.11" y2="-2.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-2.345" x2="3.055" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.345" x2="3.055" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.155" x2="3.60295" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-2.155" x2="3.60295" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-2.25" x2="3.105" y2="-2.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-1.84" x2="3.06" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.84" x2="3.06" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.66" x2="3.5916" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-1.66" x2="3.5916" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-1.75" x2="3.11" y2="-1.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-1.845" x2="3.055" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.845" x2="3.055" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.655" x2="3.60295" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-1.655" x2="3.60295" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="-1.75" x2="3.105" y2="-1.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-1.34" x2="3.06" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.34" x2="3.06" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.16" x2="3.5916" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-1.16" x2="3.5916" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-1.25" x2="3.11" y2="-1.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-1.35135" x2="3.055" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.345" x2="3.055" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.155" x2="3.60295" y2="-1.16135" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-1.16135" x2="3.60295" y2="-1.35135" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-1.25" x2="3.105" y2="-1.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-0.84" x2="3.06" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.84" x2="3.06" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.66" x2="3.5916" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-0.66" x2="3.5916" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-0.75" x2="3.11" y2="-0.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-0.845" x2="3.055" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.845" x2="3.055" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.655" x2="3.60295" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-0.655" x2="3.60295" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-0.75" x2="3.105" y2="-0.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-0.34" x2="3.06" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.34" x2="3.06" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.16" x2="3.5916" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-0.16" x2="3.5916" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-0.25" x2="3.11" y2="-0.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-0.345" x2="3.055" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.345" x2="3.055" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.155" x2="3.60295" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-0.155" x2="3.60295" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-0.25" x2="3.105" y2="-0.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="0.16" x2="3.06" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.16" x2="3.06" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.34" x2="3.5916" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="0.34" x2="3.5916" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="0.25" x2="3.11" y2="0.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="0.155" x2="3.055" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.155" x2="3.055" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.345" x2="3.60295" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="0.345" x2="3.60295" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="3.5593" y1="0.25" x2="3.105" y2="0.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="0.66" x2="3.06" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.66" x2="3.06" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.84" x2="3.5916" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="0.84" x2="3.5916" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="0.75" x2="3.11" y2="0.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="0.655" x2="3.055" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.655" x2="3.055" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.845" x2="3.60295" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="0.845" x2="3.60295" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="3.5593" y1="0.75" x2="3.105" y2="0.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="1.16" x2="3.06" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.16" x2="3.06" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.34" x2="3.5916" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="1.34" x2="3.5916" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="1.25" x2="3.11" y2="1.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="1.155" x2="3.055" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.155" x2="3.055" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.345" x2="3.60295" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="1.345" x2="3.60295" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="1.25" x2="3.105" y2="1.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="1.66" x2="3.06" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.66" x2="3.06" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.84" x2="3.5916" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="1.84" x2="3.5916" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="3.567" y1="1.75" x2="3.11" y2="1.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="1.655" x2="3.055" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.655" x2="3.055" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.845" x2="3.60295" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="1.845" x2="3.60295" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="1.75" x2="3.105" y2="1.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="2.16" x2="3.06" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.16" x2="3.06" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.34" x2="3.5916" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="2.34" x2="3.5916" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="2.25" x2="3.11" y2="2.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="2.155" x2="3.055" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.155" x2="3.055" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.345" x2="3.60295" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="2.345" x2="3.60295" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="2.25" x2="3.105" y2="2.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="2.66" x2="3.06" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.66" x2="3.06" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.84" x2="3.5916" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="2.84" x2="3.5916" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="2.75" x2="3.11" y2="2.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="2.655" x2="3.055" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.655" x2="3.055" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.845" x2="3.60295" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="2.845" x2="3.60295" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="2.75" x2="3.105" y2="2.75" width="0.1016" layer="29"/>
+<wire x1="2.84" y1="3.5916" x2="2.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="3.06" x2="2.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="3.06" x2="2.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="3.5916" x2="2.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.75" y1="3.5416" x2="2.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="2.845" y1="3.60295" x2="2.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="3.055" x2="2.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="3.055" x2="2.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="3.60295" x2="2.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.75" y1="3.55295" x2="2.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="2.34" y1="3.5916" x2="2.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="3.06" x2="2.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="3.06" x2="2.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="3.5916" x2="2.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.25" y1="3.5162" x2="2.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="2.345" y1="3.60295" x2="2.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="3.055" x2="2.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="3.055" x2="2.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="3.60295" x2="2.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.25" y1="3.56565" x2="2.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="1.84" y1="3.5916" x2="1.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="3.06" x2="1.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="3.06" x2="1.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="3.5916" x2="1.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.75" y1="3.5416" x2="1.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="1.845" y1="3.60295" x2="1.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="3.055" x2="1.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="3.055" x2="1.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="3.60295" x2="1.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.75" y1="3.55295" x2="1.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="1.34" y1="3.5916" x2="1.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="3.06" x2="1.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="3.06" x2="1.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="3.5916" x2="1.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.25" y1="3.5416" x2="1.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="1.345" y1="3.60295" x2="1.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="3.055" x2="1.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="3.055" x2="1.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="3.60295" x2="1.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.25" y1="3.5466" x2="1.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="0.84" y1="3.5916" x2="0.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="3.06" x2="0.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="3.06" x2="0.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="3.5916" x2="0.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.75" y1="3.5416" x2="0.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="0.845" y1="3.60295" x2="0.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="3.055" x2="0.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="3.055" x2="0.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="3.60295" x2="0.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.75" y1="3.54025" x2="0.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="0.34" y1="3.5916" x2="0.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="3.06" x2="0.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="3.06" x2="0.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="3.5916" x2="0.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.25" y1="3.5416" x2="0.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="0.345" y1="3.60295" x2="0.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="3.055" x2="0.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="3.055" x2="0.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="3.60295" x2="0.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.25" y1="3.5466" x2="0.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-0.16" y1="3.5916" x2="-0.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="3.06" x2="-0.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="3.06" x2="-0.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="3.5916" x2="-0.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.25" y1="3.567" x2="-0.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-0.155" y1="3.60295" x2="-0.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="3.055" x2="-0.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="3.055" x2="-0.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="3.60295" x2="-0.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.25" y1="3.5466" x2="-0.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-0.66" y1="3.5916" x2="-0.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="3.06" x2="-0.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="3.06" x2="-0.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="3.5916" x2="-0.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.75" y1="3.567" x2="-0.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-0.655" y1="3.60295" x2="-0.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="3.055" x2="-0.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="3.055" x2="-0.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="3.60295" x2="-0.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.75" y1="3.5466" x2="-0.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-1.16" y1="3.5916" x2="-1.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="3.06" x2="-1.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="3.06" x2="-1.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="3.5916" x2="-1.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.25" y1="3.5416" x2="-1.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-1.155" y1="3.60295" x2="-1.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="3.055" x2="-1.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="3.055" x2="-1.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="3.60295" x2="-1.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.25" y1="3.5593" x2="-1.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-1.66" y1="3.5916" x2="-1.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="3.06" x2="-1.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="3.06" x2="-1.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="3.5916" x2="-1.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.75" y1="3.567" x2="-1.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-1.655" y1="3.60295" x2="-1.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="3.055" x2="-1.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="3.055" x2="-1.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="3.60295" x2="-1.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.75" y1="3.572" x2="-1.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-2.16" y1="3.5916" x2="-2.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="3.06" x2="-2.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="3.06" x2="-2.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="3.5916" x2="-2.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.25" y1="3.5416" x2="-2.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-2.155" y1="3.60295" x2="-2.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="3.055" x2="-2.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="3.055" x2="-2.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="3.60295" x2="-2.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.25" y1="3.5593" x2="-2.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-2.66" y1="3.5941" x2="-2.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="3.06" x2="-2.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="3.06" x2="-2.84" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="3.5941" x2="-2.75" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="3.5941" x2="-2.66" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="3.5941" x2="-2.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-2.655" y1="3.60295" x2="-2.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="3.055" x2="-2.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="3.055" x2="-2.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="3.60295" x2="-2.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.75" y1="3.572" x2="-2.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-2.667" y1="1.27" x2="-2.667" y2="2.667" width="0.127" layer="25"/>
+<wire x1="-2.667" y1="2.667" x2="-1.27" y2="2.667" width="0.127" layer="25"/>
+<rectangle x1="-3.45" y1="2.535" x2="-3.22" y2="2.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="2.035" x2="-3.22" y2="2.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="1.535" x2="-3.22" y2="1.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="1.035" x2="-3.22" y2="1.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="0.535" x2="-3.22" y2="0.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="0.035" x2="-3.22" y2="0.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-0.465" x2="-3.22" y2="-0.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-0.965" x2="-3.22" y2="-0.535" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-1.465" x2="-3.22" y2="-1.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-1.965" x2="-3.22" y2="-1.535" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-2.465" x2="-3.22" y2="-2.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-2.965" x2="-3.22" y2="-2.535" layer="51" rot="R270"/>
+<rectangle x1="-2.865" y1="-3.55" x2="-2.635" y2="-3.12" layer="51"/>
+<rectangle x1="-2.365" y1="-3.55" x2="-2.135" y2="-3.12" layer="51"/>
+<rectangle x1="-1.865" y1="-3.55" x2="-1.635" y2="-3.12" layer="51"/>
+<rectangle x1="-1.365" y1="-3.55" x2="-1.135" y2="-3.12" layer="51"/>
+<rectangle x1="-0.865" y1="-3.55" x2="-0.635" y2="-3.12" layer="51"/>
+<rectangle x1="-0.365" y1="-3.55" x2="-0.135" y2="-3.12" layer="51"/>
+<rectangle x1="0.135" y1="-3.55" x2="0.365" y2="-3.12" layer="51"/>
+<rectangle x1="0.635" y1="-3.55" x2="0.865" y2="-3.12" layer="51"/>
+<rectangle x1="1.135" y1="-3.55" x2="1.365" y2="-3.12" layer="51"/>
+<rectangle x1="1.635" y1="-3.55" x2="1.865" y2="-3.12" layer="51"/>
+<rectangle x1="2.135" y1="-3.55" x2="2.365" y2="-3.12" layer="51"/>
+<rectangle x1="2.635" y1="-3.55" x2="2.865" y2="-3.12" layer="51"/>
+<rectangle x1="3.22" y1="-2.965" x2="3.45" y2="-2.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-2.465" x2="3.45" y2="-2.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-1.965" x2="3.45" y2="-1.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-1.465" x2="3.45" y2="-1.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-0.965" x2="3.45" y2="-0.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-0.465" x2="3.45" y2="-0.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="0.035" x2="3.45" y2="0.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="0.535" x2="3.45" y2="0.965" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="1.035" x2="3.45" y2="1.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="1.535" x2="3.45" y2="1.965" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="2.035" x2="3.45" y2="2.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="2.535" x2="3.45" y2="2.965" layer="51" rot="R90"/>
+<rectangle x1="2.635" y1="3.12" x2="2.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="2.135" y1="3.12" x2="2.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="1.635" y1="3.12" x2="1.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="1.135" y1="3.12" x2="1.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="0.635" y1="3.12" x2="0.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="0.135" y1="3.12" x2="0.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-0.365" y1="3.12" x2="-0.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-0.865" y1="3.12" x2="-0.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-1.365" y1="3.12" x2="-1.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-1.865" y1="3.12" x2="-1.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.365" y1="3.12" x2="-2.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.865" y1="3.12" x2="-2.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.286" y1="-2.286" x2="2.286" y2="2.286" layer="29"/>
+<rectangle x1="0.6985" y1="0.762" x2="1.8415" y2="1.905" layer="31"/>
+<rectangle x1="-1.8415" y1="-1.905" x2="-0.6985" y2="-0.762" layer="31"/>
+<rectangle x1="-1.905" y1="0.6985" x2="-0.762" y2="1.8415" layer="31"/>
+<rectangle x1="0.635" y1="-1.8415" x2="1.778" y2="-0.6985" layer="31"/>
+<smd name="1" x="-3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="2" x="-3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="3" x="-3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="4" x="-3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="5" x="-3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="6" x="-3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="7" x="-3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="8" x="-3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="9" x="-3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="10" x="-3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="11" x="-3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="12" x="-3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="13" x="-2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="14" x="-2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="15" x="-1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="16" x="-1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="17" x="-0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="18" x="-0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="19" x="0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="20" x="0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="21" x="1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="22" x="1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="23" x="2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="24" x="2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="25" x="3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="26" x="3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="27" x="3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="28" x="3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="29" x="3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="30" x="3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="31" x="3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="32" x="3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="33" x="3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="34" x="3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="35" x="3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="36" x="3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="37" x="2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="38" x="2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="39" x="1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="40" x="1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="41" x="0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="42" x="0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="43" x="-0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="44" x="-0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="45" x="-1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="46" x="-1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="47" x="-2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="48" x="-2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="EXP" x="0" y="0" dx="4.572" dy="4.572" layer="1" roundness="5" stop="no" cream="no"/>
+<text x="-3" y="4" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3" y="-5" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="SOP50P310X90-8N" urn="urn:adsk.eagle:footprint:35450555/2" library_version="3">
+<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="21"/>
+<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="51"/>
+<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="51"/>
+<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="51"/>
+<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="21"/>
+<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="21"/>
+<wire x1="-1.15" y1="1" x2="-1.15" y2="-1" width="0.127" layer="51"/>
+<wire x1="1.15" y1="1" x2="1.15" y2="-1" width="0.127" layer="51"/>
+<wire x1="-2.215" y1="1.25" x2="2.215" y2="1.25" width="0.05" layer="39"/>
+<wire x1="-2.215" y1="-1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
+<wire x1="-2.215" y1="1.25" x2="-2.215" y2="-1.25" width="0.05" layer="39"/>
+<wire x1="2.215" y1="1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
+<smd name="1" x="-1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="2" x="-1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="3" x="-1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="4" x="-1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="5" x="1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="6" x="1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="7" x="1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="8" x="1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<text x="0" y="0" size="1" layer="25" font="vector" align="center">&gt;NAME</text>
+</package>
+<package name="SOT23-5" urn="urn:adsk.eagle:footprint:35450556/1" library_version="3">
+<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt;</description>
+<circle x="-1.6002" y="-1.016" radius="0.127" width="0" layer="21"/>
+<wire x1="1.27" y1="0.4294" x2="1.27" y2="-0.4294" width="0.2032" layer="21"/>
+<wire x1="1.4" y1="-0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
+<wire x1="-1.27" y1="-0.4294" x2="-1.27" y2="0.4294" width="0.2032" layer="21"/>
+<wire x1="-1.4" y1="0.8" x2="1.4" y2="0.8" width="0.1524" layer="51"/>
+<wire x1="-0.2684" y1="0.7088" x2="0.2684" y2="0.7088" width="0.2032" layer="21"/>
+<wire x1="1.4" y1="0.8" x2="1.4" y2="-0.8" width="0.1524" layer="51"/>
+<wire x1="-1.4" y1="0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
+<rectangle x1="-1.2" y1="-1.5" x2="-0.7" y2="-0.85" layer="51"/>
+<rectangle x1="-0.25" y1="-1.5" x2="0.25" y2="-0.85" layer="51"/>
+<rectangle x1="0.7" y1="-1.5" x2="1.2" y2="-0.85" layer="51"/>
+<rectangle x1="0.7" y1="0.85" x2="1.2" y2="1.5" layer="51"/>
+<rectangle x1="-1.2" y1="0.85" x2="-0.7" y2="1.5" layer="51"/>
+<smd name="1" x="-0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="2" x="0" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="3" x="0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="4" x="0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="5" x="-0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
+<text x="-0.889" y="2.159" size="0.4064" layer="25">&gt;NAME</text>
+<text x="-0.9525" y="-0.1905" size="0.4064" layer="27">&gt;VALUE</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:footprint:35450548/2" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/Buttons/SMD-Button.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<circle x="0" y="0" radius="1.27" width="0.2032" layer="21"/>
+<wire x1="-1.54" y1="-2.54" x2="-2.54" y2="-1.54" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-1.24" x2="-2.54" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="1.54" x2="-1.54" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="-1.54" y1="2.54" x2="1.54" y2="2.54" width="0.2032" layer="21"/>
+<wire x1="1.54" y1="2.54" x2="2.54" y2="1.54" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="1.24" x2="2.54" y2="-1.24" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-1.54" x2="1.54" y2="-2.54" width="0.2032" layer="51"/>
+<wire x1="1.54" y1="-2.54" x2="-1.54" y2="-2.54" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="1.905" y2="0.445" width="0.127" layer="51"/>
+<wire x1="1.905" y1="0.445" x2="2.16" y2="-0.01" width="0.127" layer="51"/>
+<wire x1="1.905" y1="-0.23" x2="1.905" y2="-1.115" width="0.127" layer="51"/>
+<smd name="1" x="-2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<smd name="2" x="2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<smd name="3" x="-2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<smd name="4" x="2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<text x="0" y="0" size="1" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
+</package>
+<package name="CHIPANTENNA-1206-SHORT" urn="urn:adsk.eagle:footprint:35450559/1" library_version="3">
+<circle x="-0.7" y="0" radius="0.360553125" width="0.127" layer="21"/>
+<wire x1="-3.75" y1="4" x2="-3.75" y2="-4" width="0.0762" layer="51"/>
+<rectangle x1="-1.75" y1="-0.9" x2="1.75" y2="0.9" layer="51"/>
+<rectangle x1="-3.75" y1="-0.9" x2="-1.75" y2="0.9" layer="1"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="1"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="1"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="31"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="31"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="29"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="29"/>
+<smd name="P$1" x="-3.7" y="0" dx="0.1" dy="1.8" layer="1" stop="no" thermals="no" cream="no"/>
+<text x="-3" y="1.3" size="0.4" layer="51" rot="R90">GND Line</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="PICO-D4-QFN48" urn="urn:adsk.eagle:package:35450580/2" type="model" library_version="3">
+<description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
+48 Quad Flat Package No Leads&lt;br&gt;
+Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
+<packageinstances>
+<packageinstance name="PICO-D4-QFN48"/>
+</packageinstances>
+</package3d>
+<package3d name="SOP50P310X90-8N" urn="urn:adsk.eagle:package:35450578/3" type="model" library_version="3">
+<packageinstances>
+<packageinstance name="SOP50P310X90-8N"/>
+</packageinstances>
+</package3d>
+<package3d name="SOT23-5" urn="urn:adsk.eagle:package:35450579/2" type="model" library_version="3">
+<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt;</description>
+<packageinstances>
+<packageinstance name="SOT23-5"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:package:35450571/3" type="model" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/Buttons/SMD-Button.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_5.2MM"/>
+</packageinstances>
+</package3d>
+<package3d name="CHIPANTENNA-1206-SHORT" urn="urn:adsk.eagle:package:35450582/1" type="box" library_version="3">
+<packageinstances>
+<packageinstance name="CHIPANTENNA-1206-SHORT"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -2694,76 +2563,97 @@ LED - BLUE</description>
 <class number="0" name="default" width="0" drill="0">
 </class>
 </classes>
-<designrules name="SparkFun-4-layer-FAB-LIMIT *">
-<description language="en">&lt;b&gt;EAGLE Design Rules&lt;/b&gt;
+<designrules name="JLCPCB 4 layer">
+<description language="de">&lt;b&gt;Pixhawk DRC corrected&lt;/b&gt;
+&lt;p&gt;&lt;b&gt;Characteristics:&lt;/b&gt;&lt;/p&gt;
 &lt;p&gt;
-The default Design Rules have been set to cover
-a wide range of applications. Your particular design
-may have different requirements, so please make the
-necessary adjustments and save your customized
-design rules under a new name.</description>
-<param name="layerSetup" value="(1*2*15*16)"/>
-<param name="mtCopper" value="0.035559375mm 0.035559375mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035559375mm 0.035559375mm"/>
-<param name="mtIsolate" value="0.47751875mm 0.47751875mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.47751875mm"/>
-<param name="mdWireWire" value="5mil"/>
-<param name="mdWirePad" value="5mil"/>
-<param name="mdWireVia" value="5mil"/>
-<param name="mdPadPad" value="5mil"/>
-<param name="mdPadVia" value="5mil"/>
-<param name="mdViaVia" value="5mil"/>
-<param name="mdSmdPad" value="5mil"/>
-<param name="mdSmdVia" value="5mil"/>
-<param name="mdSmdSmd" value="5mil"/>
+&lt;ul&gt;
+&lt;li&gt;Minimum Trace/Spacing: 0.2 mm&lt;/li&gt;
+&lt;li&gt;Minimum Annular Ring: 0.15 mm&lt;/li&gt;
+&lt;li&gt;Minimum Drill: 0.3 mm&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;b&gt;Hole Tolerances&lt;/b&gt; (for reference only):&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;+/- 0.1mm for PTH holes&lt;/li&gt;
+&lt;li&gt;+/- 0.075mm for NPTH holes&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;</description>
+<description language="fr">&lt;b&gt;EAGLE Design Rules for PCBCart (Standard PCB)&lt;/b&gt;
+&lt;p&gt;&lt;b&gt;Characteristics:&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;Minimum Trace/Spacing: 8mil (0.2mm)&lt;/li&gt;
+&lt;li&gt;Minimum Annular Ring: 12mil (0.3mm)&lt;/li&gt;
+&lt;li&gt;Minimum Drill: 0.4mm (16mil)&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;b&gt;Hole Tolerances&lt;/b&gt; (for reference only):&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;+/- 0.1mm for PTH holes&lt;/li&gt;
+&lt;li&gt;+/- 0.075mm for NPTH holes&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;</description>
+<param name="layerSetup" value="(1+2*15+16)"/>
+<param name="mtCopper" value="0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm"/>
+<param name="mtIsolate" value="0.12mm 1.2mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.12mm"/>
+<param name="mdWireWire" value="0.15mm"/>
+<param name="mdWirePad" value="0.15mm"/>
+<param name="mdWireVia" value="0.15mm"/>
+<param name="mdPadPad" value="0.15mm"/>
+<param name="mdPadVia" value="0.15mm"/>
+<param name="mdViaVia" value="0.15mm"/>
+<param name="mdSmdPad" value="0.15mm"/>
+<param name="mdSmdVia" value="0mil"/>
+<param name="mdSmdSmd" value="0.15mm"/>
 <param name="mdViaViaSameLayer" value="8mil"/>
 <param name="mnLayersViaInSmd" value="2"/>
-<param name="mdCopperDimension" value="4mil"/>
-<param name="mdDrill" value="4mil"/>
+<param name="mdCopperDimension" value="0.3mm"/>
+<param name="mdDrill" value="0.2mm"/>
 <param name="mdSmdStop" value="0mil"/>
-<param name="msWidth" value="4mil"/>
-<param name="msDrill" value="6mil"/>
-<param name="msMicroVia" value="9.99mm"/>
+<param name="msWidth" value="0.15mm"/>
+<param name="msDrill" value="0.2mm"/>
+<param name="msMicroVia" value="999mil"/>
 <param name="msBlindViaRatio" value="0.5"/>
-<param name="rvPadTop" value="0.25"/>
-<param name="rvPadInner" value="0.25"/>
-<param name="rvPadBottom" value="0.25"/>
+<param name="rvPadTop" value="0.12"/>
+<param name="rvPadInner" value="0.2"/>
+<param name="rvPadBottom" value="0.12"/>
 <param name="rvViaOuter" value="0.25"/>
 <param name="rvViaInner" value="0.25"/>
 <param name="rvMicroViaOuter" value="0.25"/>
 <param name="rvMicroViaInner" value="0.25"/>
-<param name="rlMinPadTop" value="5mil"/>
+<param name="rlMinPadTop" value="0.125mm"/>
 <param name="rlMaxPadTop" value="20mil"/>
-<param name="rlMinPadInner" value="6mil"/>
+<param name="rlMinPadInner" value="0.125mm"/>
 <param name="rlMaxPadInner" value="20mil"/>
-<param name="rlMinPadBottom" value="5mil"/>
+<param name="rlMinPadBottom" value="0.125mm"/>
 <param name="rlMaxPadBottom" value="20mil"/>
-<param name="rlMinViaOuter" value="5mil"/>
+<param name="rlMinViaOuter" value="0.125mm"/>
 <param name="rlMaxViaOuter" value="20mil"/>
-<param name="rlMinViaInner" value="6mil"/>
+<param name="rlMinViaInner" value="0.125mm"/>
 <param name="rlMaxViaInner" value="20mil"/>
-<param name="rlMinMicroViaOuter" value="4mil"/>
-<param name="rlMaxMicroViaOuter" value="20mil"/>
-<param name="rlMinMicroViaInner" value="4mil"/>
-<param name="rlMaxMicroViaInner" value="20mil"/>
+<param name="rlMinMicroViaOuter" value="99mil"/>
+<param name="rlMaxMicroViaOuter" value="999mil"/>
+<param name="rlMinMicroViaInner" value="99mil"/>
+<param name="rlMaxMicroViaInner" value="999mil"/>
 <param name="psTop" value="-1"/>
 <param name="psBottom" value="-1"/>
 <param name="psFirst" value="-1"/>
 <param name="psElongationLong" value="100"/>
 <param name="psElongationOffset" value="100"/>
-<param name="mvStopFrame" value="1"/>
+<param name="mvStopFrame" value="0"/>
 <param name="mvCreamFrame" value="0"/>
 <param name="mlMinStopFrame" value="1mil"/>
-<param name="mlMaxStopFrame" value="1mil"/>
-<param name="mlMinCreamFrame" value="2mil"/>
-<param name="mlMaxCreamFrame" value="2mil"/>
-<param name="mlViaStopLimit" value="25mil"/>
+<param name="mlMaxStopFrame" value="4mil"/>
+<param name="mlMinCreamFrame" value="1mil"/>
+<param name="mlMaxCreamFrame" value="4mil"/>
+<param name="mlViaStopLimit" value="0.31mm"/>
 <param name="srRoundness" value="0"/>
 <param name="srMinRoundness" value="0mil"/>
 <param name="srMaxRoundness" value="0mil"/>
-<param name="slThermalIsolate" value="10mil"/>
+<param name="slThermalIsolate" value="8mil"/>
 <param name="slThermalsForVias" value="0"/>
 <param name="dpMaxLengthDifference" value="10mm"/>
 <param name="dpGapFactor" value="2.5"/>
-<param name="checkAngle" value="1"/>
+<param name="checkAngle" value="0"/>
 <param name="checkFont" value="1"/>
 <param name="checkRestrict" value="1"/>
 <param name="checkStop" value="0"/>
@@ -2871,17 +2761,34 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="IC1" library="bens" package="PICO-D4-QFN48" value="ESP32-PICO-D4UM-ESP32-PICO-D4" x="13.655" y="5.423" smashed="yes" rot="R180"/>
-<element name="U1" library="SparkFun-PowerIC" package="SOT23-5" value="AP2112K-3.3TRG1" x="7.178" y="2.032" smashed="yes" rot="R270">
+<element name="IC3" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" package="SOT23-5" package3d_urn="urn:adsk.eagle:package:35450579/2" value="3.3V" x="7.178" y="2.032" smashed="yes" rot="R270">
+<attribute name="MANF#" value="AP2112K-3.3TRG1" x="7.178" y="2.032" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="PROD_ID" value="VREG-12457" x="30.038" y="7.112" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="C2" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="0402" package3d_urn="urn:adsk.eagle:package:37413/1" value="0.1uF" x="18.227" y="5.334" smashed="yes" rot="R90">
-<attribute name="PROD_ID" value="CAP-12416" x="-2.093" y="-13.716" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="VALUE" x="18.989" y="5.334" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="top-center"/>
+<element name="C2" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="C0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="0.1uF" x="18.2" y="5.35" smashed="yes" rot="R90">
+<attribute name="AEC-Q" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="ALLOCATED" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="DIGIKEY#" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="LCSC#" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF#" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="NAME" x="18.2" y="5.35" size="0.4064" layer="25" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="PACKAGE" value="0402" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="VOLTAGE" value="" x="18.2" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="C1" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="0603" package3d_urn="urn:adsk.eagle:package:37414/1" value="1.0uF" x="4.257" y="2.159" smashed="yes" rot="R90">
-<attribute name="PROD_ID" value="CAP-00868" x="-16.063" y="-16.891" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="VALUE" x="5.654" y="1.143" size="0.4064" layer="27" rot="R90"/>
+<element name="C1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="C0603" package3d_urn="urn:adsk.eagle:package:2539457/2" value="1.0uF" x="4.257" y="2.159" smashed="yes" rot="R90">
+<attribute name="AEC-Q" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="ALLOCATED" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="DIGIKEY#" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="LCSC#" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF#" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="NAME" x="4.257" y="2.159" size="0.5" layer="25" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="PACKAGE" value="0603" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="3.257" y="2.159" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="VOLTAGE" value="" x="4.257" y="2.159" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
 <element name="J1" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" package="1X04_NO_SILK" package3d_urn="urn:adsk.eagle:package:38094/1" value="" x="1.59" y="9.271" smashed="yes" rot="R270">
 <attribute name="PROD_ID" value="CONN-09696" x="1.59" y="9.271" size="1.778" layer="27" rot="R270" display="off"/>
@@ -2893,50 +2800,125 @@ design rules under a new name.</description>
 <element name="TP4" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" package="PAD.03X.05" package3d_urn="urn:adsk.eagle:package:38285/1" value="TEST-POINT3X5" x="12.131" y="3.302" smashed="yes" rot="MR0"/>
 <element name="TP5" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" package="PAD.03X.05" package3d_urn="urn:adsk.eagle:package:38285/1" value="TEST-POINT3X5" x="12.131" y="8.382" smashed="yes" rot="MR0"/>
 <element name="TP6" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" package="PAD.03X.05" package3d_urn="urn:adsk.eagle:package:38285/1" value="TEST-POINT3X5" x="12.131" y="5.842" smashed="yes" rot="MR0"/>
-<element name="R3" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="0603" package3d_urn="urn:adsk.eagle:package:39650/1" value="10k" x="18.227" y="8.255" smashed="yes" rot="R270">
-<attribute name="PROD_ID" value="RES-00824" x="18.227" y="8.255" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="VALUE" value="10k" x="17.465" y="8.255" size="0.6096" layer="27" font="vector" ratio="20" rot="R270" align="top-center"/>
+<element name="R3" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0603" package3d_urn="urn:adsk.eagle:package:2539454/2" value="10k" x="18.25" y="8.25" smashed="yes" rot="R270">
+<attribute name="AEC-Q" value="" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="ALLOCATED" value="" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="DIGIKEY#" value="" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="LCSC#" value="" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF" value="" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF#" value="" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="18.25" y="8.25" size="0.5" layer="25" font="vector" ratio="15" rot="R270" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="PACKAGE" value="0603" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="TOLERANCE" value="1%" x="18.25" y="8.25" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="19.25" y="8.25" size="0.5" layer="27" font="vector" ratio="15" rot="R270" align="center"/>
 </element>
-<element name="C3" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="0603" package3d_urn="urn:adsk.eagle:package:37414/1" value="10uF" x="8.575" y="5.334" smashed="yes" rot="R90">
-<attribute name="PROD_ID" value="CAP-11015" x="8.575" y="5.334" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="VALUE" x="9.464" y="5.334" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="top-center"/>
+<element name="C3" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="C0603" package3d_urn="urn:adsk.eagle:package:2539457/2" value="10uF" x="8.55" y="5.35" smashed="yes" rot="R90">
+<attribute name="AEC-Q" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="ALLOCATED" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="DIGIKEY#" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="LCSC#" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF#" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="NAME" x="8.55" y="5.35" size="0.5" layer="25" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="PACKAGE" value="0603" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="7.55" y="5.35" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="VOLTAGE" value="" x="8.55" y="5.35" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="U$1" library="SOP50P310X90-8N" package="SOP50P310X90-8N" value="SN74LVC2T45DCUR" x="6.416" y="5.969" smashed="yes" rot="R270"/>
-<element name="R1" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="0603" package3d_urn="urn:adsk.eagle:package:39650/1" value="100" x="4.257" y="5.461" smashed="yes" rot="R90">
-<attribute name="PROD_ID" value="RES-07863" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="VALUE" x="5.019" y="5.461" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="top-center"/>
+<element name="IC2" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" package="SOP50P310X90-8N" package3d_urn="urn:adsk.eagle:package:35450578/3" value="SN74LVC2T45DCUR" x="6.416" y="5.969" smashed="yes" rot="R270">
+<attribute name="MANF#" value="SN74LVC2T45DCUR" x="6.416" y="5.969" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="R2" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="0603" package3d_urn="urn:adsk.eagle:package:39650/1" value="100" x="4.257" y="8.763" smashed="yes" rot="R90">
-<attribute name="PROD_ID" value="RES-07863" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="VALUE" x="5.019" y="8.763" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="top-center"/>
+<element name="R1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0603" package3d_urn="urn:adsk.eagle:package:2539454/2" value="100" x="4.257" y="5.461" smashed="yes" rot="R90">
+<attribute name="AEC-Q" value="" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="ALLOCATED" value="" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="DIGIKEY#" value="" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="LCSC#" value="" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF" value="" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF#" value="" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="NAME" x="4.257" y="5.461" size="0.5" layer="25" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="PACKAGE" value="0603" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="TOLERANCE" value="1%" x="4.257" y="5.461" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="3.257" y="5.461" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
 </element>
-<element name="S1" library="SparkFun-Switches" library_urn="urn:adsk.eagle:library:535" package="TACTILE_SWITCH_SMD_5.2MM" package3d_urn="urn:adsk.eagle:package:40167/1" value="MOMENTARY-SWITCH-SPST-SMD-5.2MM" x="21.783" y="5.88" smashed="yes" rot="R270">
+<element name="R2" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0603" package3d_urn="urn:adsk.eagle:package:2539454/2" value="100" x="4.257" y="8.763" smashed="yes" rot="R90">
+<attribute name="AEC-Q" value="" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="ALLOCATED" value="" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="DIGIKEY#" value="" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="LCSC#" value="" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF" value="" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="MANF#" value="" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="NAME" x="4.257" y="8.763" size="0.5" layer="25" font="vector" ratio="15" rot="R90" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="PACKAGE" value="0603" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="TOLERANCE" value="1%" x="4.257" y="8.763" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="3.257" y="8.763" size="0.5" layer="27" font="vector" ratio="15" rot="R90" align="center"/>
+</element>
+<element name="S1" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" package="TACTILE_SWITCH_SMD_5.2MM" package3d_urn="urn:adsk.eagle:package:35450571/3" value="MOMENTARY-SWITCH-SPST-SMD-5.2MM" x="21.783" y="5.88" smashed="yes" rot="R270">
+<attribute name="NAME" x="24.45" y="5.88" size="0.6096" layer="25" font="vector" ratio="20" rot="R270" align="bottom-center"/>
 <attribute name="PROD_ID" value="SWCH-08247" x="21.783" y="5.88" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="SF_SKU" value="COM-08720" x="21.783" y="5.88" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="19.116" y="5.88" size="0.6096" layer="27" font="vector" ratio="20" rot="R270" align="top-center"/>
 </element>
-<element name="U$2" library="bens" package="CHIPANTENNA-1206-SHORT" value="CHIP-ANTENNASHORT" x="30.965" y="4.953" smashed="yes" rot="R90"/>
-<element name="D1" library="SparkFun-LED" library_urn="urn:adsk.eagle:library:529" package="LED-0603" package3d_urn="urn:adsk.eagle:package:39354/1" value="" x="9.21" y="8.89" smashed="yes" rot="R90">
-<attribute name="VALUE" x="9.845" y="8.89" size="0.6096" layer="27" font="vector" ratio="20" rot="R90" align="top-center"/>
+<element name="U$2" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" package="CHIPANTENNA-1206-SHORT" package3d_urn="urn:adsk.eagle:package:35450582/1" override_package3d_urn="urn:adsk.eagle:package:35450582/2" override_package_urn="urn:adsk.eagle:footprint:35450559/1" value="CHIP-ANTENNASHORT" x="30.965" y="4.953" smashed="yes" rot="R90"/>
+<element name="LEDD1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="LED0603" package3d_urn="urn:adsk.eagle:package:2539471/4" value="LED-0603" x="9.21" y="8.89" smashed="yes" rot="R270">
+<attribute name="COLOR" value="" x="9.21" y="8.89" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="DIGIKEY#" value="" x="9.21" y="8.89" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="LCSC#" value="" x="9.21" y="8.89" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF" value="" x="9.21" y="8.89" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF#" value="" x="9.21" y="8.89" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="9.21" y="10.36" size="0.5" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
+<attribute name="PACKAGE" value="0603" x="9.21" y="8.89" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="10.21" y="8.89" size="0.5" layer="27" font="vector" ratio="15" rot="R270" align="center"/>
 </element>
-<element name="R4" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="0603" package3d_urn="urn:adsk.eagle:package:39650/1" value="100" x="6.924" y="9.652" smashed="yes">
-<attribute name="PROD_ID" value="RES-07863" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
-<attribute name="VALUE" x="6.924" y="8.89" size="0.6096" layer="27" font="vector" ratio="20" align="top-center"/>
+<element name="R4" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="R0603" package3d_urn="urn:adsk.eagle:package:2539454/2" value="100" x="6.924" y="9.652" smashed="yes">
+<attribute name="AEC-Q" value="" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="ALLOCATED" value="" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="DIGIKEY#" value="" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="LCSC#" value="" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="NAME" x="6.924" y="9.652" size="0.5" layer="25" font="vector" ratio="15" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="PACKAGE" value="0603" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="TOLERANCE" value="1%" x="6.924" y="9.652" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="6.924" y="10.652" size="0.5" layer="27" font="vector" ratio="15" align="center"/>
 </element>
-<element name="C4" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="0402" package3d_urn="urn:adsk.eagle:package:37413/1" value="0.1uF" x="10.48" y="1.016" smashed="yes" rot="R180">
-<attribute name="PROD_ID" value="CAP-12416" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="VALUE" x="10.48" y="1.778" size="0.6096" layer="27" font="vector" ratio="20" rot="R180" align="top-center"/>
+<element name="C4" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="C0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="0.1uF" x="10.48" y="1.016" smashed="yes" rot="R180">
+<attribute name="AEC-Q" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="ALLOCATED" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="DIGIKEY#" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="LCSC#" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF#" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="10.48" y="1.016" size="0.4064" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="PACKAGE" value="0402" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VOLTAGE" value="" x="10.48" y="1.016" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="C5" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" package="0402" package3d_urn="urn:adsk.eagle:package:37413/1" value="0.1uF" x="17.338" y="1.016" smashed="yes">
-<attribute name="PROD_ID" value="CAP-12416" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
-<attribute name="VALUE" x="17.338" y="0.889" size="0.6096" layer="27" font="vector" ratio="20" align="top-center"/>
+<element name="C5" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="C0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="0.1uF" x="17.338" y="1.016" smashed="yes">
+<attribute name="AEC-Q" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="ALLOCATED" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="DIGIKEY#" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="LCSC#" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="MANF" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="MANF#" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="OPERATING_TEMP" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="PACKAGE" value="0402" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
+<attribute name="VOLTAGE" value="" x="17.338" y="1.016" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C6" library="Seeed-Capacitor" library_urn="urn:adsk.eagle:library:464" package="C0402" package3d_urn="urn:adsk.eagle:package:32379/1" value="1.6PF" x="21.91" y="1.524" smashed="yes" rot="R270">
-<attribute name="MPN" value="CC0402BRNPO9BN1R5" x="21.91" y="1.524" size="1.778" layer="27" rot="R270" display="off"/>
-<attribute name="VALUE" x="23.307" y="3.048" size="0.635" layer="27" font="vector" ratio="10" rot="R180"/>
-</element>
-<element name="L1" library="Seeed-Inductor" library_urn="urn:adsk.eagle:library:471" package="L0402" package3d_urn="urn:adsk.eagle:package:32722/1" value="1.8NH" x="20.513" y="1.143" smashed="yes" rot="R90"/>
-<element name="L2" library="Seeed-Inductor" library_urn="urn:adsk.eagle:library:471" package="L0402" package3d_urn="urn:adsk.eagle:package:32722/1" value="1.8NH" x="23.307" y="1.143" smashed="yes" rot="R90">
-<attribute name="MPN" value="LQG15HS4N7S02" x="23.307" y="1.143" size="1.778" layer="27" rot="R90" display="off"/>
+<element name="C6" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="C0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="1.6PF" x="21.9" y="1.6" smashed="yes" rot="R180">
+<attribute name="AEC-Q" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="ALLOCATED" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="DIGIKEY#" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="LCSC#" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MANF#" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="21.9" y="1.6" size="0.4064" layer="25" font="vector" ratio="15" rot="R180" align="center"/>
+<attribute name="OPERATING_TEMP" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="PACKAGE" value="0402" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VOLTAGE" value="" x="21.9" y="1.6" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
 <element name="U$3" library="Electro_Mage_pcb4_pixel_6" package="ELECTRO_MAGE_PCB4_PIXEL_2#PNG" value="" x="21.656" y="5.334" smashed="yes" rot="MR0"/>
 <element name="J2" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" package="1X04_NO_SILK" package3d_urn="urn:adsk.eagle:package:38094/1" value="" x="0" y="9.271" smashed="yes" rot="R270">
@@ -2944,48 +2926,56 @@ design rules under a new name.</description>
 <attribute name="PROD_ID" value="CONN-09696" x="0" y="9.271" size="1.778" layer="27" rot="R270" display="off"/>
 <attribute name="VALUE" x="-2.032" y="10.541" size="0.6096" layer="27" font="vector" ratio="20" rot="R270"/>
 </element>
+<element name="L2" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="L0402" package3d_urn="urn:adsk.eagle:package:5347945/2" value="L-0402" x="20.4" y="1.1" smashed="yes" rot="R270">
+<attribute name="ALLOCATED" value="" x="20.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="DIGIKEY#" value="" x="20.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="LCSC#" value="" x="20.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF" value="" x="20.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF#" value="" x="20.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="20.4" y="1.1" size="0.5" layer="25" font="vector" ratio="12" rot="R270" align="center"/>
+</element>
+<element name="L1" library="rc" library_urn="urn:adsk.eagle:library:2539423" package="L0402" package3d_urn="urn:adsk.eagle:package:5347945/2" value="L-0402" x="23.4" y="1.1" smashed="yes" rot="R270">
+<attribute name="ALLOCATED" value="" x="23.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="DIGIKEY#" value="" x="23.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="LCSC#" value="" x="23.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF" value="" x="23.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MANF#" value="" x="23.4" y="1.1" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="23.4" y="1.1" size="0.5" layer="25" font="vector" ratio="12" rot="R270" align="center"/>
+</element>
+<element name="IC4" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" package="PICO-D4-QFN48" package3d_urn="urn:adsk.eagle:package:35450580/2" value="ESP32-PICO-D4UM-ESP32-PICO-D4" x="13.655" y="5.423" smashed="yes" rot="R180">
+<attribute name="NAME" x="16.655" y="1.423" size="1.27" layer="25" rot="R180"/>
+<attribute name="VALUE" x="16.655" y="10.423" size="1.27" layer="27" rot="R180"/>
+</element>
 </elements>
 <signals>
-<signal name="SENSOR_CAPN">
-<contactref element="IC1" pad="7"/>
-</signal>
-<signal name="IO12">
-<contactref element="IC1" pad="18"/>
-</signal>
-<signal name="IO21">
-<contactref element="IC1" pad="42"/>
-</signal>
 <signal name="N$1">
 <contactref element="U$2" pad="P$1"/>
 <contactref element="C6" pad="1"/>
-<contactref element="L2" pad="2"/>
-<wire x1="23.307" y1="1.6055" x2="25.7015" y2="1.6055" width="0.762" layer="1"/>
-<wire x1="25.7015" y1="1.6055" x2="30.6125" y2="1.6055" width="0.762" layer="1"/>
-<wire x1="30.965" y1="1.253" x2="30.6125" y2="1.6055" width="0.127" layer="1"/>
-<wire x1="22.799" y1="1.524" x2="23.2255" y2="1.524" width="0.762" layer="1"/>
-<wire x1="23.2255" y1="1.524" x2="23.307" y2="1.6055" width="0.762" layer="1"/>
-<wire x1="22.3725" y1="1.524" x2="22.799" y2="1.524" width="0.508" layer="1"/>
+<wire x1="24.3515" y1="1.6055" x2="30.9625" y2="1.6055" width="0.762" layer="1"/>
+<contactref element="L1" pad="1"/>
+<wire x1="22.4" y1="1.6" x2="23.4" y2="1.6" width="0.5" layer="1"/>
+<wire x1="23.4" y1="1.6" x2="23.4055" y2="1.6055" width="0.5" layer="1"/>
+<wire x1="23.4055" y1="1.6055" x2="24.3515" y2="1.6055" width="0.5" layer="1"/>
+<wire x1="30.9625" y1="1.6055" x2="30.965" y2="1.253" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="GND">
-<contactref element="IC1" pad="EXP"/>
 <contactref element="C1" pad="2"/>
-<contactref element="U1" pad="2"/>
+<contactref element="IC3" pad="2"/>
 <contactref element="C2" pad="2"/>
 <contactref element="J1" pad="1"/>
 <contactref element="TP6" pad="P$1"/>
 <contactref element="C3" pad="2"/>
-<via x="15.56" y="7.0866" extent="1-16" drill="0.35"/>
-<via x="15.5346" y="4.572" extent="1-16" drill="0.35"/>
-<via x="12.639" y="4.572" extent="1-16" drill="0.35"/>
-<via x="11.75" y="7.112" extent="1-16" drill="0.35"/>
-<wire x1="13.655" y1="5.423" x2="13.909" y2="5.169" width="0.1524" layer="1"/>
+<via x="15.56" y="7.0866" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="15.5346" y="4.572" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="12.639" y="4.572" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="11.75" y="7.112" extent="1-16" drill="0.3" diameter="0.6"/>
 <polygon width="0.1524" layer="15" isolate="0.254">
 <vertex x="2.733" y="10.795"/>
 <vertex x="24.831" y="10.795"/>
 <vertex x="24.831" y="0"/>
 <vertex x="2.733" y="0"/>
 </polygon>
-<contactref element="U$1" pad="4"/>
+<contactref element="IC2" pad="4"/>
 <polygon width="0.1524" layer="16" isolate="0.254">
 <vertex x="2.6822" y="0"/>
 <vertex x="24.831" y="0"/>
@@ -2993,63 +2983,58 @@ design rules under a new name.</description>
 <vertex x="2.6822" y="10.795"/>
 </polygon>
 <contactref element="S1" pad="1"/>
-<wire x1="8.575" y1="6.184" x2="8.1178" y2="6.6412" width="0.1524" layer="1"/>
-<wire x1="8.1178" y1="6.6412" x2="8.1178" y2="7.0866" width="0.1524" layer="1"/>
-<via x="8.1178" y="7.0866" extent="1-16" drill="0.35"/>
+<wire x1="8.55" y1="6.075" x2="8.1678" y2="6.075" width="0.1524" layer="1"/>
+<wire x1="8.1678" y1="7.0366" x2="8.1678" y2="6.075" width="0.15" layer="1"/>
+<wire x1="8.1678" y1="7.0366" x2="8.1178" y2="7.0866" width="0.1524" layer="1"/>
+<via x="8.1178" y="7.0866" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="5.666" y1="8.624" x2="5.666" y2="7.374" width="0.1524" layer="1"/>
 <wire x1="5.666" y1="8.624" x2="5.654" y2="8.636" width="0.1524" layer="1"/>
-<via x="5.654" y="8.636" extent="1-16" drill="0.35"/>
+<via x="5.654" y="8.636" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="11.75" y1="7.112" x2="12.131" y2="6.731" width="0.1524" layer="16"/>
 <wire x1="12.131" y1="6.731" x2="12.131" y2="5.842" width="0.1524" layer="16"/>
-<wire x1="4.257" y1="3.009" x2="5.234" y2="2.032" width="0.3048" layer="1"/>
-<wire x1="5.234" y1="2.032" x2="5.8779" y2="2.032" width="0.3048" layer="1"/>
+<wire x1="5.8779" y1="2.032" x2="5.3779" y2="2.032" width="0.3048" layer="1"/>
+<wire x1="5.3779" y1="2.032" x2="4.5259" y2="2.884" width="0.3048" layer="1"/>
+<wire x1="4.257" y1="2.884" x2="4.5259" y2="2.884" width="0.3048" layer="1"/>
 <wire x1="6.6954" y1="2.0066" x2="5.9033" y2="2.0066" width="0.3048" layer="1"/>
 <wire x1="5.8779" y1="2.032" x2="5.9033" y2="2.0066" width="0.3048" layer="1"/>
-<via x="6.6954" y="2.0066" extent="1-16" drill="0.35"/>
+<via x="6.6954" y="2.0066" extent="1-16" drill="0.3" diameter="0.6"/>
 <contactref element="R4" pad="1"/>
-<wire x1="6.074" y1="9.652" x2="6.074" y2="9.056" width="0.1524" layer="1"/>
-<wire x1="6.074" y1="9.056" x2="5.654" y2="8.636" width="0.1524" layer="1"/>
+<wire x1="6.199" y1="9.652" x2="6.199" y2="9.502" width="0.1524" layer="1"/>
+<wire x1="6.199" y1="9.502" x2="5.800446875" y2="9.103446875" width="0.1524" layer="1"/>
+<wire x1="5.800446875" y1="9.103446875" x2="5.654" y2="8.74989375" width="0.1524" layer="1" curve="45"/>
+<wire x1="5.654" y1="8.74989375" x2="5.654" y2="8.636" width="0.1524" layer="1"/>
 <contactref element="C5" pad="2"/>
 <contactref element="C4" pad="2"/>
-<wire x1="9.9" y1="1.2192" x2="9.9" y2="1.016" width="0.254" layer="1"/>
-<wire x1="9.21" y1="1.778" x2="9.3412" y2="1.778" width="0.254" layer="1"/>
-<wire x1="9.3412" y1="1.778" x2="9.9" y2="1.2192" width="0.254" layer="1"/>
-<via x="9.21" y="1.778" extent="1-16" drill="0.35"/>
-<wire x1="19.243" y1="5.969" x2="18.282" y2="5.969" width="0.3048" layer="1"/>
-<wire x1="18.227" y1="5.914" x2="18.282" y2="5.969" width="0.3048" layer="1"/>
-<via x="19.243" y="5.969" extent="1-16" drill="0.35"/>
-<wire x1="13.655" y1="5.423" x2="11.966" y2="7.112" width="0.3048" layer="1"/>
+<wire x1="9.98" y1="1.016" x2="9.98" y2="1.0392" width="0.254" layer="1"/>
+<wire x1="9.98" y1="1.0392" x2="9.26" y2="1.7592" width="0.254" layer="1"/>
+<wire x1="9.26" y1="1.828" x2="9.26" y2="1.7592" width="0.254" layer="1"/>
+<via x="9.26" y="1.828" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="19.243" y1="5.969" x2="19.224" y2="5.95" width="0.3048" layer="1"/>
+<wire x1="19.224" y1="5.95" x2="18.223628125" y2="5.95" width="0.3048" layer="1"/>
+<wire x1="18.223628125" y1="5.85" x2="18.223628125" y2="5.95" width="0.3048" layer="1"/>
+<via x="19.243" y="5.969" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="11.966" y1="7.112" x2="11.75" y2="7.112" width="0.3048" layer="1"/>
 <wire x1="1.59" y1="9.271" x2="2.987" y2="9.271" width="0.3048" layer="15"/>
 <wire x1="2.987" y1="9.271" x2="3.368" y2="8.89" width="0.3048" layer="15"/>
-<via x="2.86" y="10.033" extent="1-16" drill="0.35"/>
-<via x="18.862" y="0.762" extent="1-16" drill="0.35"/>
-<wire x1="23.688" y1="8.674" x2="20.983" y2="5.969" width="0.1524" layer="1"/>
-<wire x1="20.983" y1="5.969" x2="19.243" y2="5.969" width="0.1524" layer="1"/>
-<contactref element="L2" pad="1"/>
-<contactref element="L1" pad="1"/>
-<wire x1="21.275" y1="0.6805" x2="22.545" y2="0.6805" width="0.508" layer="1"/>
-<wire x1="23.307" y1="0.6805" x2="22.545" y2="0.6805" width="0.508" layer="1"/>
-<via x="22.545" y="0.6805" extent="1-16" drill="0.35"/>
-<wire x1="20.513" y1="0.6805" x2="21.275" y2="0.6805" width="0.508" layer="1"/>
-<via x="21.275" y="0.6805" extent="1-16" drill="0.35"/>
-<wire x1="18.9435" y1="0.6805" x2="18.862" y2="0.762" width="0.508" layer="1"/>
-<wire x1="18.862" y1="0.762" x2="18.172" y2="0.762" width="0.508" layer="1"/>
-<wire x1="18.172" y1="0.762" x2="17.918" y2="1.016" width="0.508" layer="1"/>
-<via x="21.91" y="0.6805" extent="1-16" drill="0.35"/>
-<via x="24.577" y="0.6805" extent="1-16" drill="0.35"/>
-<via x="24.577" y="2.5855" extent="1-16" drill="0.35"/>
-<via x="24.577" y="3.8555" extent="1-16" drill="0.35"/>
-<via x="24.577" y="5.1255" extent="1-16" drill="0.35"/>
-<via x="24.577" y="6.3955" extent="1-16" drill="0.35"/>
-<via x="24.577" y="7.6655" extent="1-16" drill="0.35"/>
-<via x="24.577" y="8.9355" extent="1-16" drill="0.35"/>
-<via x="24.577" y="10.0785" extent="1-16" drill="0.35"/>
-<via x="23.307" y="10.0785" extent="1-16" drill="0.35"/>
-<via x="22.037" y="10.0785" extent="1-16" drill="0.35"/>
-<via x="20.767" y="10.0785" extent="1-16" drill="0.35"/>
-<via x="14.6964" y="10.0277" extent="1-16" drill="0.35"/>
-<via x="14.417" y="0.6805" extent="1-16" drill="0.35"/>
+<via x="18.862" y="0.762" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="23.688" y1="8.674" x2="23.388" y2="8.374" width="0.1524" layer="1"/>
+<wire x1="23.388" y1="8.374" x2="23.388" y2="7.469" width="0.1524" layer="1"/>
+<wire x1="23.388" y1="7.469" x2="21.888" y2="5.969" width="0.1524" layer="1" curve="-90"/>
+<wire x1="21.888" y1="5.969" x2="19.243" y2="5.969" width="0.1524" layer="1"/>
+<via x="21.9" y="0.6" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="0.6805" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="2.5855" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="3.8555" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="5.1255" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="6.3955" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="7.6655" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="8.9355" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="24.577" y="10.0785" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="23.307" y="10.0785" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="22.037" y="10.0785" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="20.767" y="10.0785" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="14.6964" y="10.0277" extent="1-16" drill="0.3" diameter="0.6"/>
+<via x="14.417" y="0.6805" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="24.323" y1="6.985" x2="24.323" y2="6.604" width="0.508" layer="16"/>
 <wire x1="24.323" y1="6.604" x2="24.45" y2="6.477" width="0.508" layer="16"/>
 <wire x1="22.418" y1="6.35" x2="22.418" y2="5.842" width="0.508" layer="16"/>
@@ -3059,34 +3044,29 @@ design rules under a new name.</description>
 <wire x1="20.894" y1="1.524" x2="20.894" y2="1.651" width="0.508" layer="16"/>
 <wire x1="18.608" y1="2.54" x2="18.608" y2="3.048" width="0.508" layer="16"/>
 <wire x1="17.846" y1="6.223" x2="18.1" y2="5.969" width="0.508" layer="16"/>
-<wire x1="18.1" y1="8.255" x2="18.0365" y2="8.1915" width="0.508" layer="16"/>
-<wire x1="18.0365" y1="8.1915" x2="17.973" y2="8.128" width="0.508" layer="16"/>
 <wire x1="20.767" y1="8.128" x2="20.64" y2="8.001" width="0.508" layer="16"/>
 <wire x1="20.64" y1="8.001" x2="20.513" y2="8.001" width="0.508" layer="16"/>
-<wire x1="18.0365" y1="8.1915" x2="17.338" y2="7.493" width="0.1524" layer="16"/>
 <wire x1="17.338" y1="7.493" x2="17.338" y2="6.35" width="0.1524" layer="16"/>
 <contactref element="J2" pad="1"/>
 <wire x1="0" y1="9.271" x2="1.59" y2="9.271" width="2.032" layer="1"/>
 <wire x1="0" y1="9.271" x2="1.59" y2="9.271" width="2.032" layer="2"/>
 <wire x1="0" y1="9.271" x2="1.59" y2="9.271" width="2.032" layer="15"/>
 <wire x1="0" y1="9.271" x2="1.59" y2="9.271" width="2.032" layer="16"/>
-<wire x1="1.59" y1="9.271" x2="2.8194" y2="9.271" width="0.4064" layer="16"/>
-<wire x1="2.8194" y1="9.271" x2="2.8956" y2="9.3472" width="0.4064" layer="16"/>
-<wire x1="2.8956" y1="9.3472" x2="2.8956" y2="9.9974" width="0.4064" layer="16"/>
-<wire x1="2.8956" y1="9.9974" x2="2.86" y2="10.033" width="0.4064" layer="16"/>
-<wire x1="1.59" y1="9.271" x2="2.8194" y2="9.271" width="0.4064" layer="1"/>
-<wire x1="2.8194" y1="9.271" x2="2.8702" y2="9.3218" width="0.4064" layer="1"/>
-<wire x1="2.8702" y1="9.3218" x2="2.8702" y2="10.0228" width="0.4064" layer="1"/>
-<wire x1="2.8702" y1="10.0228" x2="2.86" y2="10.033" width="0.4064" layer="1"/>
+<wire x1="4.522" y1="9.271" x2="1.59" y2="9.271" width="1" layer="16"/>
+<contactref element="L2" pad="2"/>
+<contactref element="L1" pad="2"/>
+<contactref element="IC4" pad="EXP"/>
+<wire x1="20.4" y1="0.6" x2="21.9" y2="0.6" width="0.5" layer="1"/>
+<wire x1="23.4" y1="0.6" x2="21.9" y2="0.6" width="0.5" layer="1"/>
+<wire x1="18.862" y1="0.762" x2="18.451209375" y2="0.762" width="0.508" layer="1"/>
+<wire x1="18.451209375" y1="0.762" x2="17.838" y2="1.016" width="0.508" layer="1" curve="-45"/>
+<wire x1="13.655" y1="5.423" x2="12.804" y2="4.572" width="0.508" layer="1"/>
+<wire x1="12.804" y1="4.572" x2="12.639" y2="4.572" width="0.508" layer="1"/>
+<wire x1="18.223628125" y1="5.85" x2="18.2" y2="5.85" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="+3V3">
-<contactref element="IC1" pad="1"/>
-<contactref element="IC1" pad="3"/>
-<contactref element="IC1" pad="4"/>
-<contactref element="IC1" pad="37"/>
-<contactref element="IC1" pad="19"/>
 <contactref element="C2" pad="1"/>
-<contactref element="U1" pad="5"/>
+<contactref element="IC3" pad="5"/>
 <contactref element="R3" pad="1"/>
 <contactref element="TP5" pad="P$1"/>
 <contactref element="C3" pad="1"/>
@@ -3096,86 +3076,94 @@ design rules under a new name.</description>
 <vertex x="18.2016" y="0"/>
 <vertex x="5.1968" y="0"/>
 </polygon>
-<contactref element="U$1" pad="1"/>
-<contactref element="U$1" pad="5"/>
-<contactref element="IC1" pad="43"/>
-<contactref element="IC1" pad="46"/>
-<wire x1="8.4781" y1="2.982" x2="8.4781" y2="4.0234" width="0.3048" layer="1"/>
-<wire x1="8.575" y1="4.1203" x2="8.4781" y2="4.0234" width="0.3048" layer="1"/>
-<wire x1="8.575" y1="4.484" x2="8.575" y2="4.1203" width="0.3048" layer="1"/>
+<contactref element="IC2" pad="1"/>
+<contactref element="IC2" pad="5"/>
+<wire x1="8.4781" y1="2.982" x2="8.5781" y2="2.982" width="0.3048" layer="1"/>
+<wire x1="8.55" y1="4.625" x2="8.5781" y2="4.5969" width="0.3048" layer="1"/>
+<wire x1="8.5781" y1="4.5969" x2="8.5781" y2="2.982" width="0.3048" layer="1"/>
 <wire x1="8.448" y1="2.9519" x2="8.4781" y2="2.982" width="0.3048" layer="1"/>
 <wire x1="8.448" y1="2.9519" x2="8.448" y2="2.286" width="0.3048" layer="1"/>
-<via x="8.448" y="2.286" extent="1-16" drill="0.35"/>
-<wire x1="5.666" y1="4.564" x2="5.666" y2="5.576" width="0.1524" layer="1"/>
-<wire x1="5.666" y1="5.576" x2="5.527" y2="5.715" width="0.1524" layer="1"/>
-<via x="5.527" y="5.715" extent="1-16" drill="0.35"/>
-<wire x1="7.166" y1="7.374" x2="7.166" y2="6.743" width="0.1524" layer="1"/>
-<wire x1="7.166" y1="6.743" x2="7.432" y2="6.477" width="0.1524" layer="1"/>
-<via x="7.432" y="6.477" extent="1-16" drill="0.35"/>
+<via x="8.448" y="2.286" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="5.666" y1="4.564" x2="5.666" y2="5.379425" width="0.1524" layer="1"/>
+<wire x1="5.666" y1="5.379425" x2="5.527" y2="5.715" width="0.1524" layer="1" curve="45"/>
+<via x="5.527" y="5.715" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="7.166" y1="7.374" x2="7.166" y2="6.95010625" width="0.1524" layer="1"/>
+<wire x1="7.166" y1="6.95010625" x2="7.312446875" y2="6.596553125" width="0.1524" layer="1" curve="45"/>
+<wire x1="7.312446875" y1="6.596553125" x2="7.432" y2="6.477" width="0.1524" layer="1"/>
+<via x="7.432" y="6.477" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="16.9824" y1="3.673" x2="16.9824" y2="4.173" width="0.3048" layer="1"/>
-<via x="18.1" y="4.2164" extent="1-16" drill="0.35"/>
+<via x="18.1" y="4.2" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="13.405" y1="8.7504" x2="13.405" y2="9.521" width="0.3048" layer="1"/>
 <wire x1="13.405" y1="9.521" x2="13.401" y2="9.525" width="0.3048" layer="1"/>
-<via x="13.401" y="9.525" extent="1-16" drill="0.35"/>
+<via x="13.401" y="9.525" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="12.131" y1="8.382" x2="13.274" y2="9.525" width="0.3048" layer="16"/>
 <wire x1="13.274" y1="9.525" x2="13.401" y2="9.525" width="0.3048" layer="16"/>
 <contactref element="C5" pad="1"/>
 <contactref element="C4" pad="1"/>
 <wire x1="10.905" y1="2.0956" x2="10.905" y2="1.171" width="0.254" layer="1"/>
-<wire x1="10.905" y1="1.171" x2="11.06" y2="1.016" width="0.254" layer="1"/>
-<wire x1="16.9824" y1="2.673" x2="17.012" y2="2.6434" width="0.254" layer="1"/>
-<wire x1="16.758" y1="1.016" x2="17.012" y2="1.016" width="0.254" layer="1"/>
-<wire x1="16.758" y1="1.016" x2="15.9579" y2="1.016" width="0.254" layer="1"/>
-<wire x1="15.9579" y1="1.016" x2="15.6597" y2="1.3142" width="0.254" layer="1"/>
-<wire x1="14.17615" y1="1.3142" x2="13.905" y2="1.58535" width="0.254" layer="1"/>
-<wire x1="13.905" y1="1.58535" x2="13.905" y2="2.0956" width="0.254" layer="1"/>
-<wire x1="15.6597" y1="1.3142" x2="14.17615" y2="1.3142" width="0.254" layer="1"/>
-<wire x1="15.7124" y1="1.3396" x2="15.6174" y2="1.3396" width="0.254" layer="1"/>
-<wire x1="15.7378" y1="1.3142" x2="14.17615" y2="1.3142" width="0.254" layer="1"/>
-<wire x1="15.687" y1="1.27" x2="15.6174" y2="1.3396" width="0.254" layer="1"/>
-<wire x1="15.7124" y1="1.3396" x2="15.7378" y2="1.3142" width="0.254" layer="1"/>
-<wire x1="17.012" y1="2.6434" x2="17.012" y2="1.016" width="0.254" layer="1"/>
-<via x="15.687" y="1.27" extent="1-16" drill="0.35"/>
-<wire x1="15.687" y1="1.27" x2="15.6108" y2="1.3462" width="0.3048" layer="1"/>
-<wire x1="15.6108" y1="1.3462" x2="15.405" y2="1.3462" width="0.3048" layer="1"/>
-<wire x1="15.405" y1="1.3462" x2="15.405" y2="2.0956" width="0.3048" layer="1"/>
-<wire x1="15.687" y1="1.27" x2="15.719" y2="1.238" width="0.3048" layer="1"/>
-<wire x1="18.1" y1="4.2164" x2="17.7952" y2="4.2164" width="0.3048" layer="1"/>
-<wire x1="17.7952" y1="4.2164" x2="17.7518" y2="4.173" width="0.3048" layer="1"/>
-<wire x1="17.7518" y1="4.173" x2="16.9824" y2="4.173" width="0.3048" layer="1"/>
-<wire x1="18.227" y1="4.754" x2="18.227" y2="4.3434" width="0.3048" layer="1"/>
-<wire x1="18.227" y1="4.3434" x2="18.1" y2="4.2164" width="0.3048" layer="1"/>
-<wire x1="18.227" y1="9.105" x2="17.631" y2="9.105" width="0.1524" layer="1"/>
-<wire x1="17.631" y1="9.105" x2="17.592" y2="9.144" width="0.1524" layer="1"/>
-<via x="17.592" y="9.144" extent="1-16" drill="0.35"/>
-<wire x1="8.4781" y1="2.982" x2="9.0068" y2="2.982" width="0.254" layer="1"/>
-<wire x1="10.8796" y1="2.121" x2="9.8678" y2="2.121" width="0.254" layer="1"/>
+<wire x1="10.905" y1="1.171" x2="10.98" y2="1.016" width="0.254" layer="1"/>
+<wire x1="16.838" y1="1.016" x2="16.95" y2="1.016" width="0.254" layer="1"/>
+<wire x1="16.838" y1="1.016" x2="16.838" y2="1.0859" width="0.254" layer="1"/>
+<wire x1="16.838" y1="1.0859" x2="16.7597" y2="1.1642" width="0.254" layer="1"/>
+<wire x1="16.9824" y1="2.673" x2="16.95" y2="2.6406" width="0.254" layer="1"/>
+<wire x1="16.95" y1="2.6406" x2="16.95" y2="1.016" width="0.254" layer="1"/>
+<via x="15.687" y="1.27" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="18.1" y1="4.2" x2="18.1" y2="4.173" width="0.3048" layer="1"/>
+<wire x1="18.1" y1="4.173" x2="16.9824" y2="4.173" width="0.3048" layer="1"/>
+<wire x1="18.2" y1="4.85" x2="18.1" y2="4.75" width="0.3048" layer="1"/>
+<wire x1="18.1" y1="4.75" x2="18.1" y2="4.2" width="0.3048" layer="1"/>
+<via x="17.242" y="9.194" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="8.6281" y1="2.832" x2="8.94969375" y2="2.832" width="0.254" layer="1"/>
+<wire x1="8.94969375" y1="2.832" x2="9.303246875" y2="2.685553125" width="0.254" layer="1" curve="-45"/>
+<wire x1="9.303246875" y1="2.685553125" x2="9.721353125" y2="2.267446875" width="0.254" layer="1"/>
+<wire x1="8.4781" y1="2.982" x2="8.6281" y2="2.832" width="0.254" layer="1"/>
+<wire x1="9.721353125" y1="2.267446875" x2="10.07490625" y2="2.121" width="0.254" layer="1" curve="45"/>
+<wire x1="10.07490625" y1="2.121" x2="10.8796" y2="2.121" width="0.254" layer="1"/>
 <wire x1="10.8796" y1="2.121" x2="10.905" y2="2.0956" width="0.254" layer="1"/>
-<wire x1="9.0068" y1="2.982" x2="9.8678" y2="2.121" width="0.254" layer="1"/>
+<contactref element="IC4" pad="37"/>
+<contactref element="IC4" pad="19"/>
+<contactref element="IC4" pad="1"/>
+<contactref element="IC4" pad="3"/>
+<contactref element="IC4" pad="43"/>
+<contactref element="IC4" pad="46"/>
+<contactref element="IC4" pad="4"/>
+<wire x1="13.905" y1="2.0956" x2="13.905" y2="1.8142" width="0.25" layer="1"/>
+<wire x1="13.905" y1="1.8142" x2="14.405" y2="1.3142" width="0.25" layer="1" curve="90"/>
+<wire x1="14.405" y1="1.3142" x2="15.4" y2="1.3142" width="0.25" layer="1"/>
+<wire x1="15.6428" y1="1.3142" x2="15.687" y2="1.27" width="0.25" layer="1"/>
+<wire x1="15.4" y1="1.3142" x2="15.6428" y2="1.3142" width="0.25" layer="1"/>
+<wire x1="15.405" y1="2.0956" x2="15.405" y2="1.3192" width="0.25" layer="1"/>
+<wire x1="15.405" y1="1.3192" x2="15.4" y2="1.3142" width="0.25" layer="1"/>
+<wire x1="16.838" y1="1.016" x2="16.14810625" y2="1.016" width="0.25" layer="1"/>
+<wire x1="16.14810625" y1="1.016" x2="15.794553125" y2="1.162446875" width="0.25" layer="1" curve="-45"/>
+<wire x1="15.794553125" y1="1.162446875" x2="15.687" y2="1.27" width="0.25" layer="1"/>
+<wire x1="18.25" y1="8.975" x2="18.031" y2="9.194" width="0.1524" layer="1"/>
+<wire x1="18.031" y1="9.194" x2="17.242" y2="9.194" width="0.1524" layer="1"/>
 </signal>
 <signal name="+5V">
 <contactref element="C1" pad="1"/>
-<contactref element="U1" pad="1"/>
-<contactref element="U1" pad="3"/>
+<contactref element="IC3" pad="1"/>
+<contactref element="IC3" pad="3"/>
 <contactref element="J1" pad="4"/>
-<contactref element="U$1" pad="8"/>
+<contactref element="IC2" pad="8"/>
 <contactref element="J2" pad="4"/>
 <wire x1="0" y1="1.651" x2="1.59" y2="1.651" width="2.032" layer="1"/>
-<wire x1="1.59" y1="1.651" x2="1.6205" y2="1.6205" width="2.032" layer="1"/>
 <wire x1="0" y1="1.651" x2="1.59" y2="1.651" width="2.032" layer="2"/>
 <wire x1="0" y1="1.651" x2="1.59" y2="1.651" width="2.032" layer="15"/>
 <wire x1="0" y1="1.651" x2="1.59" y2="1.651" width="2.032" layer="16"/>
-<wire x1="4.257" y1="1.309" x2="1.932" y2="1.309" width="0.4064" layer="1"/>
-<wire x1="1.932" y1="1.309" x2="1.59" y2="1.651" width="0.4064" layer="1"/>
-<wire x1="5.8779" y1="1.082" x2="4.484" y2="1.082" width="0.4064" layer="1"/>
-<wire x1="4.484" y1="1.082" x2="4.257" y2="1.309" width="0.4064" layer="1"/>
-<wire x1="5.8779" y1="1.082" x2="7.0764" y2="1.082" width="0.4064" layer="1"/>
-<wire x1="7.0764" y1="1.082" x2="7.3914" y2="1.397" width="0.4064" layer="1"/>
-<wire x1="7.3914" y1="1.397" x2="7.3914" y2="2.5908" width="0.4064" layer="1"/>
-<wire x1="7.3914" y1="2.5908" x2="7.0002" y2="2.982" width="0.4064" layer="1"/>
-<wire x1="7.0002" y1="2.982" x2="5.8779" y2="2.982" width="0.4064" layer="1"/>
-<wire x1="7.166" y1="4.564" x2="7.166" y2="3.1478" width="0.3048" layer="1"/>
-<wire x1="7.166" y1="3.1478" x2="7.0002" y2="2.982" width="0.3048" layer="1"/>
+<wire x1="4.257" y1="1.434" x2="4.19" y2="1.501" width="0.4064" layer="1"/>
+<wire x1="4.19" y1="1.501" x2="1.74" y2="1.501" width="0.4064" layer="1"/>
+<wire x1="1.59" y1="1.651" x2="1.74" y2="1.501" width="0.4064" layer="1"/>
+<wire x1="5.8779" y1="1.082" x2="5.1732125" y2="1.082" width="0.4064" layer="1"/>
+<wire x1="5.1732125" y1="1.082" x2="4.46610625" y2="1.37489375" width="0.4064" layer="1" curve="-45"/>
+<wire x1="4.46610625" y1="1.37489375" x2="4.407" y2="1.434" width="0.4064" layer="1"/>
+<wire x1="4.407" y1="1.434" x2="4.257" y2="1.434" width="0.4064" layer="1"/>
+<wire x1="5.8779" y1="1.082" x2="6.8914" y2="1.082" width="0.4064" layer="1"/>
+<wire x1="6.8914" y1="1.082" x2="7.3914" y2="1.582" width="0.4064" layer="1" curve="90"/>
+<wire x1="7.3914" y1="1.582" x2="7.3914" y2="2.7566" width="0.4064" layer="1"/>
+<wire x1="7.3914" y1="2.7566" x2="7.166" y2="2.982" width="0.4064" layer="1" curve="90"/>
+<wire x1="7.166" y1="4.564" x2="7.166" y2="2.982" width="0.3048" layer="1"/>
+<wire x1="7.166" y1="2.982" x2="5.8779" y2="2.982" width="0.4064" layer="1"/>
 </signal>
 <signal name="SDO_OUT">
 <contactref element="J1" pad="2"/>
@@ -3185,8 +3173,9 @@ design rules under a new name.</description>
 <wire x1="0" y1="6.731" x2="1.59" y2="6.731" width="2.032" layer="2"/>
 <wire x1="0" y1="6.731" x2="1.59" y2="6.731" width="2.032" layer="15"/>
 <wire x1="0" y1="6.731" x2="1.59" y2="6.731" width="2.032" layer="16"/>
-<wire x1="4.257" y1="9.613" x2="1.59" y2="6.946" width="0.3048" layer="1"/>
-<wire x1="1.59" y1="6.946" x2="1.59" y2="6.731" width="0.3048" layer="1"/>
+<wire x1="4.257" y1="9.488" x2="4.107" y2="9.488" width="0.3048" layer="1"/>
+<wire x1="4.107" y1="9.488" x2="1.47" y2="6.851" width="0.3048" layer="1"/>
+<wire x1="1.59" y1="6.731" x2="1.47" y2="6.851" width="0.3048" layer="1"/>
 </signal>
 <signal name="SCK_OUT">
 <contactref element="J1" pad="3"/>
@@ -3196,139 +3185,207 @@ design rules under a new name.</description>
 <wire x1="0" y1="4.191" x2="1.59" y2="4.191" width="2.032" layer="2"/>
 <wire x1="0" y1="4.191" x2="1.59" y2="4.191" width="2.032" layer="15"/>
 <wire x1="0" y1="4.191" x2="1.59" y2="4.191" width="2.032" layer="16"/>
-<wire x1="4.257" y1="6.311" x2="2.137" y2="4.191" width="0.3048" layer="1"/>
-<wire x1="2.137" y1="4.191" x2="1.59" y2="4.191" width="0.3048" layer="1"/>
+<wire x1="4.257" y1="6.186" x2="4.107" y2="6.036" width="0.3048" layer="1"/>
+<wire x1="4.107" y1="6.036" x2="3.885" y2="6.036" width="0.3048" layer="1"/>
+<wire x1="3.885" y1="6.036" x2="2.04" y2="4.191" width="0.3048" layer="1"/>
+<wire x1="1.59" y1="4.191" x2="2.04" y2="4.191" width="0.3048" layer="1"/>
 </signal>
 <signal name="EN">
-<contactref element="IC1" pad="9"/>
 <contactref element="TP3" pad="P$1"/>
 <contactref element="R3" pad="2"/>
-<wire x1="18.227" y1="7.405" x2="17.495" y2="6.673" width="0.1524" layer="1"/>
-<wire x1="17.495" y1="6.673" x2="16.9824" y2="6.673" width="0.1524" layer="1"/>
-<via x="15.941" y="9.906" extent="1-16" drill="0.35"/>
-<wire x1="18.227" y1="7.405" x2="20.3512" y2="7.405" width="0.1524" layer="1"/>
-<wire x1="20.3512" y1="7.405" x2="20.5892" y2="7.643" width="0.1524" layer="1"/>
-<wire x1="20.5892" y1="7.643" x2="20.5892" y2="9.49476875" width="0.1524" layer="1"/>
+<wire x1="18.25" y1="7.525" x2="17.9" y2="7.525" width="0.1524" layer="1"/>
+<wire x1="16.9824" y1="6.673" x2="17.4" y2="6.673" width="0.1524" layer="1"/>
+<wire x1="17.4" y1="6.673" x2="17.9" y2="7.173" width="0.1524" layer="1" curve="90"/>
+<wire x1="17.9" y1="7.173" x2="17.9" y2="7.525" width="0.1524" layer="1"/>
+<via x="15.941" y="9.906" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="18.25" y1="7.525" x2="19.9892" y2="7.525" width="0.1524" layer="1"/>
+<wire x1="19.9892" y1="7.525" x2="20.5892" y2="8.125" width="0.1524" layer="1" curve="90"/>
+<wire x1="20.5892" y1="8.125" x2="20.5892" y2="9.1582" width="0.1524" layer="1"/>
+<wire x1="20.5892" y1="9.1582" x2="19.8892" y2="9.8582" width="0.1524" layer="1" curve="90"/>
+<wire x1="19.8892" y1="9.8582" x2="15.9888" y2="9.8582" width="0.1524" layer="1"/>
 <wire x1="15.9888" y1="9.8582" x2="15.941" y2="9.906" width="0.1524" layer="1"/>
-<wire x1="20.5892" y1="9.49476875" x2="20.22576875" y2="9.8582" width="0.1524" layer="1"/>
-<wire x1="20.22576875" y1="9.8582" x2="15.9888" y2="9.8582" width="0.1524" layer="1"/>
 <wire x1="15.941" y1="9.906" x2="14.671" y2="8.636" width="0.1524" layer="16"/>
 <wire x1="14.671" y1="8.636" x2="14.671" y2="8.382" width="0.1524" layer="16"/>
+<contactref element="IC4" pad="9"/>
 </signal>
 <signal name="U0TX">
 <contactref element="TP2" pad="P$1"/>
-<contactref element="IC1" pad="41"/>
-<via x="13.2486" y="1.0922" extent="1-16" drill="0.35"/>
-<wire x1="14.671" y1="3.302" x2="14.671" y2="2.5146" width="0.1524" layer="16"/>
-<wire x1="12.905" y1="2.0956" x2="12.905" y2="1.4358" width="0.1524" layer="1"/>
-<wire x1="12.905" y1="1.4358" x2="13.2486" y2="1.0922" width="0.1524" layer="1"/>
-<wire x1="14.671" y1="2.5146" x2="13.2486" y2="1.0922" width="0.1524" layer="16"/>
+<via x="13.2486" y="1.0922" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="14.671" y1="3.302" x2="14.671" y2="2.9288125" width="0.1524" layer="16"/>
+<wire x1="14.671" y1="2.9288125" x2="14.37810625" y2="2.22170625" width="0.1524" layer="16" curve="-45"/>
+<wire x1="14.37810625" y1="2.22170625" x2="13.2486" y2="1.0922" width="0.1524" layer="16"/>
+<wire x1="12.905" y1="2.0956" x2="12.905" y2="1.64290625" width="0.1524" layer="1"/>
+<wire x1="12.905" y1="1.64290625" x2="13.051446875" y2="1.289353125" width="0.1524" layer="1" curve="45"/>
+<wire x1="13.051446875" y1="1.289353125" x2="13.2486" y2="1.0922" width="0.1524" layer="1"/>
+<contactref element="IC4" pad="41"/>
 </signal>
 <signal name="UORX">
-<contactref element="IC1" pad="40"/>
 <contactref element="TP1" pad="P$1"/>
-<via x="12.258" y="1.0668" extent="1-16" drill="0.35"/>
-<wire x1="13.401" y1="2.667" x2="12.385" y2="1.651" width="0.1524" layer="16"/>
-<wire x1="14.671" y1="5.842" x2="14.671" y2="5.207" width="0.1524" layer="16"/>
-<wire x1="14.671" y1="5.207" x2="13.401" y2="3.937" width="0.1524" layer="16"/>
-<wire x1="13.401" y1="3.937" x2="13.401" y2="2.667" width="0.1524" layer="16"/>
-<wire x1="12.258" y1="1.0668" x2="12.405" y2="1.2138" width="0.1524" layer="1"/>
-<wire x1="12.405" y1="1.2138" x2="12.405" y2="2.0956" width="0.1524" layer="1"/>
-<wire x1="12.385" y1="1.651" x2="12.385" y2="1.1938" width="0.1524" layer="16"/>
+<via x="12.258" y="1.0668" extent="1-16" drill="0.3" diameter="0.6"/>
+<wire x1="13.451" y1="3.2227875" x2="13.451" y2="3.1312125" width="0.1524" layer="16"/>
+<wire x1="13.451" y1="3.1312125" x2="13.15810625" y2="2.42410625" width="0.1524" layer="16" curve="-45"/>
+<wire x1="13.15810625" y1="2.42410625" x2="12.67789375" y2="1.94389375" width="0.1524" layer="16"/>
+<wire x1="12.67789375" y1="1.94389375" x2="12.385" y2="1.2367875" width="0.1524" layer="16" curve="45"/>
+<wire x1="12.385" y1="1.2367875" x2="12.385" y2="1.1938" width="0.1524" layer="16"/>
+<wire x1="14.671" y1="5.842" x2="14.671" y2="5.2712125" width="0.1524" layer="16"/>
+<wire x1="14.671" y1="5.2712125" x2="14.37810625" y2="4.56410625" width="0.1524" layer="16" curve="-45"/>
+<wire x1="14.37810625" y1="4.56410625" x2="13.74389375" y2="3.92989375" width="0.1524" layer="16"/>
+<wire x1="13.74389375" y1="3.92989375" x2="13.451" y2="3.2227875" width="0.1524" layer="16" curve="45"/>
+<wire x1="12.258" y1="1.0668" x2="12.258553125" y2="1.067353125" width="0.1524" layer="1"/>
+<wire x1="12.258553125" y1="1.067353125" x2="12.405" y2="1.42090625" width="0.1524" layer="1" curve="45"/>
+<wire x1="12.405" y1="1.42090625" x2="12.405" y2="2.0956" width="0.1524" layer="1"/>
 <wire x1="12.385" y1="1.1938" x2="12.258" y2="1.0668" width="0.1524" layer="16"/>
+<contactref element="IC4" pad="40"/>
 </signal>
 <signal name="IO0">
-<contactref element="IC1" pad="23"/>
 <contactref element="TP4" pad="P$1"/>
-<wire x1="12.131" y1="3.302" x2="10.861" y2="4.572" width="0.1524" layer="16"/>
-<wire x1="10.861" y1="4.572" x2="10.861" y2="9.652" width="0.1524" layer="16"/>
-<via x="10.861" y="9.652" extent="1-16" drill="0.35"/>
+<wire x1="12.131" y1="3.302" x2="11.15389375" y2="4.27910625" width="0.1524" layer="16"/>
+<wire x1="11.15389375" y1="4.27910625" x2="10.861" y2="4.9862125" width="0.1524" layer="16" curve="-45"/>
+<wire x1="10.861" y1="4.9862125" x2="10.861" y2="9.652" width="0.1524" layer="16"/>
+<via x="10.861" y="9.652" extent="1-16" drill="0.3" diameter="0.6"/>
 <wire x1="10.861" y1="9.652" x2="11.405" y2="9.108" width="0.1524" layer="1"/>
 <wire x1="11.405" y1="9.108" x2="11.405" y2="8.7504" width="0.1524" layer="1"/>
+<contactref element="IC4" pad="23"/>
 </signal>
 <signal name="SCK">
-<contactref element="IC1" pad="35"/>
-<contactref element="U$1" pad="2"/>
-<wire x1="6.666" y1="7.9636" x2="6.9412" y2="8.2388" width="0.1524" layer="1"/>
-<wire x1="6.666" y1="7.374" x2="6.666" y2="7.9636" width="0.1524" layer="1"/>
-<wire x1="9.88919375" y1="3.173" x2="10.3276" y2="3.173" width="0.1524" layer="1"/>
-<wire x1="9.88919375" y1="3.173" x2="9.6478" y2="3.41439375" width="0.1524" layer="1"/>
-<wire x1="6.9412" y1="8.2388" x2="7.6800625" y2="8.2388" width="0.1524" layer="1"/>
-<wire x1="7.6800625" y1="8.2388" x2="8.7814625" y2="7.1374" width="0.1524" layer="1"/>
-<wire x1="9.6478" y1="6.8114" x2="9.6478" y2="3.41439375" width="0.1524" layer="1"/>
-<wire x1="8.7814625" y1="7.1374" x2="9.3218" y2="7.1374" width="0.1524" layer="1"/>
-<wire x1="9.3218" y1="7.1374" x2="9.6478" y2="6.8114" width="0.1524" layer="1"/>
+<contactref element="IC2" pad="2"/>
+<wire x1="6.666" y1="7.374" x2="6.666" y2="7.9388" width="0.1524" layer="1"/>
+<wire x1="6.666" y1="7.9388" x2="6.966" y2="8.2388" width="0.1524" layer="1" curve="-90"/>
+<wire x1="6.966" y1="8.2388" x2="7.46585" y2="8.2388" width="0.1524" layer="1"/>
+<wire x1="7.46585" y1="8.2388" x2="8.17295625" y2="7.94590625" width="0.1524" layer="1" curve="-45"/>
+<wire x1="8.17295625" y1="7.94590625" x2="9.35490625" y2="6.76395625" width="0.1524" layer="1"/>
+<wire x1="9.35490625" y1="6.76395625" x2="9.6478" y2="6.05685" width="0.1524" layer="1" curve="-45"/>
+<wire x1="9.6478" y1="6.05685" x2="9.6478" y2="3.573" width="0.1524" layer="1"/>
+<wire x1="9.6478" y1="3.573" x2="10.0478" y2="3.173" width="0.1524" layer="1" curve="90"/>
+<wire x1="10.0478" y1="3.173" x2="10.3276" y2="3.173" width="0.1524" layer="1"/>
+<contactref element="IC4" pad="35"/>
 </signal>
 <signal name="SDO">
-<contactref element="IC1" pad="36"/>
-<contactref element="U$1" pad="3"/>
-<wire x1="9.15916875" y1="5.3134" x2="7.5354" y2="5.3134" width="0.1524" layer="1"/>
-<wire x1="7.5354" y1="5.3134" x2="6.166" y2="6.6828" width="0.1524" layer="1"/>
-<wire x1="6.166" y1="6.6828" x2="6.166" y2="7.374" width="0.1524" layer="1"/>
-<wire x1="10.3276" y1="2.673" x2="9.93999375" y2="2.673" width="0.1524" layer="1"/>
-<wire x1="9.93999375" y1="2.673" x2="9.3684" y2="3.24459375" width="0.1524" layer="1"/>
-<wire x1="9.3684" y1="3.24459375" x2="9.3684" y2="5.10416875" width="0.1524" layer="1"/>
-<wire x1="9.3684" y1="5.10416875" x2="9.15916875" y2="5.3134" width="0.1524" layer="1"/>
+<contactref element="IC2" pad="3"/>
+<wire x1="9.793546875" y1="2.819446875" x2="9.446446875" y2="3.166546875" width="0.1524" layer="1"/>
+<wire x1="9.446446875" y1="3.166546875" x2="9.3" y2="3.5201" width="0.1524" layer="1" curve="-45"/>
+<wire x1="9.3" y1="3.5201" x2="9.3" y2="4.8134" width="0.1524" layer="1"/>
+<wire x1="9.3" y1="4.8134" x2="8.8" y2="5.3134" width="0.1524" layer="1" curve="90"/>
+<wire x1="8.8" y1="5.3134" x2="7.8996125" y2="5.3134" width="0.1524" layer="1"/>
+<wire x1="7.8996125" y1="5.3134" x2="7.19250625" y2="5.60629375" width="0.1524" layer="1" curve="-45"/>
+<wire x1="7.19250625" y1="5.60629375" x2="6.312446875" y2="6.486353125" width="0.1524" layer="1"/>
+<wire x1="6.312446875" y1="6.486353125" x2="6.166" y2="6.83990625" width="0.1524" layer="1" curve="-45"/>
+<wire x1="6.166" y1="6.83990625" x2="6.166" y2="7.374" width="0.1524" layer="1"/>
+<wire x1="10.3276" y1="2.673" x2="10.1471" y2="2.673" width="0.1524" layer="1"/>
+<wire x1="10.1471" y1="2.673" x2="9.793546875" y2="2.819446875" width="0.1524" layer="1" curve="-45"/>
+<contactref element="IC4" pad="36"/>
 </signal>
 <signal name="N$4">
-<contactref element="U$1" pad="7"/>
+<contactref element="IC2" pad="7"/>
 <contactref element="R1" pad="1"/>
-<wire x1="6.6312" y1="3.8126" x2="6.4924" y2="3.6738" width="0.1524" layer="1"/>
-<wire x1="6.666" y1="4.564" x2="6.6312" y2="4.5292" width="0.1524" layer="1"/>
-<wire x1="6.6312" y1="4.5292" x2="6.6312" y2="3.8126" width="0.1524" layer="1"/>
-<wire x1="6.4924" y1="3.6738" x2="5.1942" y2="3.6738" width="0.1524" layer="1"/>
-<wire x1="5.1942" y1="3.6738" x2="4.257" y2="4.611" width="0.1524" layer="1"/>
+<wire x1="6.666" y1="4.564" x2="6.6812" y2="4.5488" width="0.1524" layer="1"/>
+<wire x1="6.6812" y1="4.5488" x2="6.6812" y2="4.0238" width="0.1524" layer="1"/>
+<wire x1="6.6812" y1="4.0238" x2="6.3312" y2="3.6738" width="0.1524" layer="1" curve="-90"/>
+<wire x1="4.607" y1="4.736" x2="4.607" y2="4.1738" width="0.1524" layer="1"/>
+<wire x1="4.607" y1="4.1738" x2="5.107" y2="3.6738" width="0.1524" layer="1" curve="90"/>
+<wire x1="5.107" y1="3.6738" x2="6.3312" y2="3.6738" width="0.1524" layer="1"/>
+<wire x1="4.257" y1="4.736" x2="4.607" y2="4.736" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$5">
-<contactref element="U$1" pad="6"/>
+<contactref element="IC2" pad="6"/>
 <contactref element="R2" pad="1"/>
 <wire x1="6.166" y1="4.564" x2="6.162" y2="4.568" width="0.1524" layer="1"/>
-<wire x1="6.162" y1="4.568" x2="6.162" y2="5.842" width="0.1524" layer="1"/>
-<wire x1="6.162" y1="5.842" x2="4.257" y2="7.747" width="0.1524" layer="1"/>
-<wire x1="4.257" y1="7.747" x2="4.257" y2="7.913" width="0.1524" layer="1"/>
+<wire x1="4.753446875" y1="7.250553125" x2="5.86910625" y2="6.13489375" width="0.1524" layer="1"/>
+<wire x1="5.86910625" y1="6.13489375" x2="6.162" y2="5.4277875" width="0.1524" layer="1" curve="-45"/>
+<wire x1="6.162" y1="5.4277875" x2="6.162" y2="4.568" width="0.1524" layer="1"/>
+<wire x1="4.607" y1="8.038" x2="4.607" y2="7.60410625" width="0.1524" layer="1"/>
+<wire x1="4.607" y1="7.60410625" x2="4.753446875" y2="7.250553125" width="0.1524" layer="1" curve="45"/>
+<wire x1="4.607" y1="8.038" x2="4.257" y2="8.038" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$2">
-<contactref element="IC1" pad="17"/>
-<contactref element="D1" pad="A"/>
-<wire x1="10.61145625" y1="10.1826" x2="10.305" y2="9.87614375" width="0.1524" layer="1"/>
-<wire x1="14.405" y1="8.7504" x2="14.405" y2="9.27574375" width="0.1524" layer="1"/>
-<wire x1="14.405" y1="9.27574375" x2="13.49814375" y2="10.1826" width="0.1524" layer="1"/>
-<wire x1="10.305" y1="9.87614375" x2="10.305" y2="9.108" width="0.1524" layer="1"/>
-<wire x1="13.49814375" y1="10.1826" x2="10.61145625" y2="10.1826" width="0.1524" layer="1"/>
-<wire x1="10.305" y1="9.108" x2="9.21" y2="8.013" width="0.1524" layer="1"/>
+<contactref element="LEDD1" pad="A"/>
+<wire x1="14.405" y1="8.7504" x2="14.405" y2="9.08579375" width="0.1524" layer="1"/>
+<wire x1="14.405" y1="9.08579375" x2="14.199975" y2="9.58076875" width="0.1524" layer="1" curve="45"/>
+<wire x1="14.199975" y1="9.58076875" x2="13.80316875" y2="9.977575" width="0.1524" layer="1"/>
+<wire x1="13.80316875" y1="9.977575" x2="13.30819375" y2="10.1826" width="0.1524" layer="1" curve="45"/>
+<wire x1="13.30819375" y1="10.1826" x2="10.855" y2="10.1826" width="0.1524" layer="1"/>
+<wire x1="10.855" y1="10.1826" x2="10.155" y2="9.4826" width="0.1524" layer="1" curve="90"/>
+<wire x1="10.155" y1="9.4826" x2="10.155" y2="9.24995" width="0.1524" layer="1"/>
+<wire x1="10.155" y1="9.24995" x2="9.949975" y2="8.754975" width="0.1524" layer="1" curve="-45"/>
+<wire x1="9.949975" y1="8.754975" x2="9.36" y2="8.165" width="0.1524" layer="1"/>
+<wire x1="9.36" y1="8.165" x2="9.21" y2="8.165" width="0.1524" layer="1"/>
+<contactref element="IC4" pad="17"/>
 </signal>
 <signal name="N$3">
-<contactref element="D1" pad="C"/>
+<contactref element="LEDD1" pad="C"/>
 <contactref element="R4" pad="2"/>
-<wire x1="7.774" y1="9.652" x2="9.095" y2="9.652" width="0.1524" layer="1"/>
-<wire x1="9.095" y1="9.652" x2="9.21" y2="9.767" width="0.1524" layer="1"/>
+<wire x1="7.649" y1="9.652" x2="9.095" y2="9.652" width="0.1524" layer="1"/>
+<wire x1="9.095" y1="9.652" x2="9.21" y2="9.615" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$6">
-<contactref element="IC1" pad="2"/>
 <contactref element="C6" pad="2"/>
-<contactref element="L1" pad="2"/>
-<wire x1="17.8206" y1="3.173" x2="16.9824" y2="3.173" width="0.4064" layer="1"/>
-<wire x1="17.8206" y1="3.173" x2="19.3881" y2="1.6055" width="0.762" layer="1"/>
-<wire x1="19.3881" y1="1.6055" x2="20.513" y2="1.6055" width="0.762" layer="1"/>
-<wire x1="20.894" y1="1.6055" x2="20.513" y2="1.6055" width="0.762" layer="1"/>
-<wire x1="21.4475" y1="1.524" x2="20.9755" y2="1.524" width="0.508" layer="1"/>
-<wire x1="20.9755" y1="1.524" x2="20.894" y2="1.6055" width="0.508" layer="1"/>
+<wire x1="17.6706" y1="3.173" x2="16.9824" y2="3.173" width="0.35" layer="1"/>
+<contactref element="L2" pad="1"/>
+<contactref element="IC4" pad="2"/>
+<wire x1="20.4" y1="1.6" x2="21.4" y2="1.6" width="0.5" layer="1"/>
+<wire x1="20.4" y1="1.6" x2="19.864921875" y2="1.6" width="0.5" layer="1"/>
+<wire x1="19.864921875" y1="1.6" x2="18.804259375" y2="2.039340625" width="0.5" layer="1" curve="-45.000084"/>
+<wire x1="18.804259375" y1="2.039340625" x2="17.6706" y2="3.173" width="0.5" layer="1"/>
 </signal>
 <signal name="BUTTON">
-<contactref element="IC1" pad="12"/>
 <contactref element="S1" pad="3"/>
-<wire x1="16.9824" y1="8.173" x2="17.338" y2="8.173" width="0.1524" layer="1"/>
-<wire x1="19.377" y1="8.173" x2="17.338" y2="8.173" width="0.1524" layer="1"/>
-<wire x1="19.377" y1="8.173" x2="19.878" y2="8.674" width="0.1524" layer="1"/>
+<wire x1="19.877" y1="8.173" x2="16.9824" y2="8.173" width="0.1524" layer="1"/>
+<wire x1="19.878" y1="8.174" x2="19.878" y2="8.674" width="0.1524" layer="1"/>
+<wire x1="19.878" y1="8.174" x2="19.877" y2="8.173" width="0.1524" layer="1"/>
+<contactref element="IC4" pad="12"/>
+</signal>
+<signal name="IO12">
+<contactref element="IC4" pad="18"/>
+</signal>
+<signal name="IO21">
+<contactref element="IC4" pad="42"/>
+</signal>
+<signal name="SENSOR_CAPN">
+<contactref element="IC4" pad="7"/>
 </signal>
 </signals>
 <mfgpreviewcolors>
-<mfgpreviewcolor name="soldermaskcolor" color="0xC8008000"/>
+<mfgpreviewcolor name="soldermaskcolor" color="0xC8000000"/>
 <mfgpreviewcolor name="silkscreencolor" color="0xFFFEFEFE"/>
 <mfgpreviewcolor name="backgroundcolor" color="0xFF282828"/>
-<mfgpreviewcolor name="coppercolor" color="0xFFFFBF00"/>
+<mfgpreviewcolor name="coppercolor" color="0xFFC0C0C0"/>
 <mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
 </mfgpreviewcolors>
+<errors>
+<approved hash="3,16,137ccf3f4f3f937c"/>
+<approved hash="4,1,d9ffe4b666b65bff"/>
+<approved hash="4,1,ba45d399ab9cc447"/>
+<approved hash="4,1,f2a9fd887f8870a9"/>
+<approved hash="4,1,9295fb4d834aec97"/>
+<approved hash="4,1,e610f06172616410"/>
+<approved hash="4,1,8859e1d599d8f657"/>
+<approved hash="4,1,cd56d8cf5acf4f56"/>
+<approved hash="4,1,9319fae982eaed07"/>
+<approved hash="4,2,b8c080798679bec0"/>
+<approved hash="4,2,91969f0f990f9796"/>
+<approved hash="4,2,85698ca08aa08369"/>
+<approved hash="4,2,8859e1d599d8f657"/>
+<approved hash="4,2,ac9bb5d2b3d2aa9b"/>
+<approved hash="4,2,9295fb4d834aec97"/>
+<approved hash="4,2,ba45d399ab9cc447"/>
+<approved hash="4,2,9319fae982eaed07"/>
+<approved hash="4,15,8859e1d599d8f657"/>
+<approved hash="4,15,b8c080798679bec0"/>
+<approved hash="4,15,9319fae982eaed07"/>
+<approved hash="4,15,91969f0f990f9796"/>
+<approved hash="4,15,85698ca08aa08369"/>
+<approved hash="4,15,ac9bb5d2b3d2aa9b"/>
+<approved hash="4,15,9295fb4d834aec97"/>
+<approved hash="4,15,ba45d399ab9cc447"/>
+<approved hash="4,16,d9ffe4b666b65bff"/>
+<approved hash="4,16,9295fb4d834aec97"/>
+<approved hash="4,16,f2a9fd887f8870a9"/>
+<approved hash="4,16,8859e1d599d8f657"/>
+<approved hash="4,16,e610f06172616410"/>
+<approved hash="4,16,cd56d8cf5acf4f56"/>
+<approved hash="4,16,ba45d399ab9cc447"/>
+<approved hash="4,16,9319fae982eaed07"/>
+</errors>
 </board>
 </drawing>
 <compatibility>
@@ -3342,6 +3399,11 @@ of those online libraries will not be understood (or retained)
 with this version.
 </note>
 <note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports Fusion synchronisation.
+This feature will not be available in this version and saving
+the document will break the link to the Fusion PCB feature.
+</note>
+<note version="8.3" severity="warning">
 Since Version 8.3, EAGLE supports URNs for individual library
 assets (packages, symbols, and devices). The URNs of those assets
 will not be understood (or retained) with this version.
@@ -3350,6 +3412,11 @@ will not be understood (or retained) with this version.
 Since Version 8.3, EAGLE supports the association of 3D packages
 with devices in libraries, schematics, and board files. Those 3D
 packages will not be understood (or retained) with this version.
+</note>
+<note version="9.4" severity="warning">
+Since Version 9.4, EAGLE supports the overriding of 3D packages
+in schematics and board files. Those overridden 3d packages
+will not be understood (or retained) with this version.
 </note>
 </compatibility>
 </eagle>

--- a/V3/hardware/PB32Pico_1.x.sch
+++ b/V3/hardware/PB32Pico_1.x.sch
@@ -3,7 +3,7 @@
 <eagle version="9.6.2">
 <drawing>
 <settings>
-<setting alwaysvectorfont="yes"/>
+<setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
 <grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
@@ -64,8 +64,10 @@
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
 <layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="58" name="bCAD" color="9" fill="1" visible="no" active="no"/>
 <layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="61" name="stand" color="7" fill="1" visible="no" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
@@ -134,6 +136,8 @@
 <layer number="153" name="FabDoc1" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="154" name="FabDoc2" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="155" name="FabDoc3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="166" name="AntennaArea" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="168" name="4mmHeightArea" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="191" name="mNets" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="192" name="mBusses" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="193" name="mPins" color="7" fill="1" visible="yes" active="yes"/>
@@ -195,11 +199,6 @@
 <packages>
 </packages>
 <symbols>
-<symbol name="GND" urn="urn:adsk.eagle:symbol:26925/1" library_version="1">
-<wire x1="-1.905" y1="0" x2="1.905" y2="0" width="0.254" layer="94"/>
-<text x="-2.54" y="-2.54" size="1.778" layer="96">&gt;VALUE</text>
-<pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
-</symbol>
 <symbol name="+3V3" urn="urn:adsk.eagle:symbol:26950/1" library_version="1">
 <wire x1="1.27" y1="-1.905" x2="0" y2="0" width="0.254" layer="94"/>
 <wire x1="0" y1="0" x2="-1.27" y2="-1.905" width="0.254" layer="94"/>
@@ -208,19 +207,6 @@
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="GND" urn="urn:adsk.eagle:component:26954/1" prefix="GND" library_version="1">
-<description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
-<gates>
-<gate name="1" symbol="GND" x="0" y="0"/>
-</gates>
-<devices>
-<device name="">
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
 <deviceset name="+3V3" urn="urn:adsk.eagle:component:26981/1" prefix="+3V3" library_version="1">
 <description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
 <gates>
@@ -253,11 +239,6 @@
 <text x="-2.54" y="-5.08" size="1.778" layer="96" rot="R90">&gt;VALUE</text>
 <pin name="+3V3" x="0" y="-2.54" visible="off" length="short" direction="sup" rot="R90"/>
 </symbol>
-<symbol name="GND">
-<wire x1="-1.905" y1="0" x2="1.905" y2="0" width="0.254" layer="94"/>
-<text x="-2.54" y="-2.54" size="1.778" layer="96">&gt;VALUE</text>
-<pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
-</symbol>
 <symbol name="+5V">
 <wire x1="1.27" y1="-1.905" x2="0" y2="0" width="0.254" layer="94"/>
 <wire x1="0" y1="0" x2="-1.27" y2="-1.905" width="0.254" layer="94"/>
@@ -279,19 +260,6 @@
 </device>
 </devices>
 </deviceset>
-<deviceset name="GND" prefix="GND">
-<description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
-<gates>
-<gate name="1" symbol="GND" x="0" y="0"/>
-</gates>
-<devices>
-<device name="">
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
 <deviceset name="+5V" prefix="P+">
 <description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
 <gates>
@@ -301,100 +269,6 @@
 <device name="">
 <technologies>
 <technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
-<library name="SparkFun-PowerIC">
-<description>&lt;h3&gt;SparkFun Electronics' preferred foot prints&lt;/h3&gt;
-In this library you'll find drivers, regulators, and amplifiers.&lt;br&gt;&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is the end user's responsibility to ensure correctness and suitablity for a given componet or application. If you enjoy using this library, please buy one of our products at www.sparkfun.com.
-&lt;br&gt;&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
-<packages>
-<package name="SOT23-5">
-<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt;</description>
-<wire x1="1.27" y1="0.4294" x2="1.27" y2="-0.4294" width="0.2032" layer="21"/>
-<wire x1="1.4" y1="-0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
-<wire x1="-1.27" y1="-0.4294" x2="-1.27" y2="0.4294" width="0.2032" layer="21"/>
-<wire x1="-1.4" y1="0.8" x2="1.4" y2="0.8" width="0.1524" layer="51"/>
-<wire x1="-0.2684" y1="0.7088" x2="0.2684" y2="0.7088" width="0.2032" layer="21"/>
-<wire x1="1.4" y1="0.8" x2="1.4" y2="-0.8" width="0.1524" layer="51"/>
-<wire x1="-1.4" y1="0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
-<rectangle x1="-1.2" y1="-1.5" x2="-0.7" y2="-0.85" layer="51"/>
-<rectangle x1="-0.25" y1="-1.5" x2="0.25" y2="-0.85" layer="51"/>
-<rectangle x1="0.7" y1="-1.5" x2="1.2" y2="-0.85" layer="51"/>
-<rectangle x1="0.7" y1="0.85" x2="1.2" y2="1.5" layer="51"/>
-<rectangle x1="-1.2" y1="0.85" x2="-0.7" y2="1.5" layer="51"/>
-<smd name="1" x="-0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="2" x="0" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="3" x="0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="4" x="0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
-<smd name="5" x="-0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
-<text x="-0.889" y="2.159" size="0.4064" layer="25">&gt;NAME</text>
-<text x="-0.9525" y="-0.1905" size="0.4064" layer="27">&gt;VALUE</text>
-<circle x="-1.6002" y="-1.016" radius="0.127" width="0" layer="21"/>
-</package>
-</packages>
-<symbols>
-<symbol name="V-REG-LDO_NO-BP">
-<wire x1="-7.62" y1="-7.62" x2="5.08" y2="-7.62" width="0.4064" layer="94"/>
-<wire x1="5.08" y1="-7.62" x2="5.08" y2="7.62" width="0.4064" layer="94"/>
-<wire x1="5.08" y1="7.62" x2="-7.62" y2="7.62" width="0.4064" layer="94"/>
-<wire x1="-7.62" y1="7.62" x2="-7.62" y2="-7.62" width="0.4064" layer="94"/>
-<text x="-7.62" y="9.144" size="1.778" layer="95">&gt;NAME</text>
-<text x="-7.62" y="-11.43" size="1.778" layer="96">&gt;VALUE</text>
-<pin name="IN" x="-10.16" y="5.08" visible="pin" length="short" direction="in"/>
-<pin name="GND" x="-10.16" y="-5.08" visible="pin" length="short" direction="in"/>
-<pin name="OUT" x="7.62" y="5.08" visible="pin" length="short" direction="pas" rot="R180"/>
-<pin name="EN" x="-10.16" y="0" visible="pin" length="short" direction="in"/>
-<pin name="NC" x="7.62" y="-5.08" visible="pin" length="short" direction="in" rot="R180"/>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="V_REG_AP2112" prefix="U">
-<description>&lt;h3&gt;AP2112 - 600mA CMOS LDO Regulator w/ Enable&lt;/h3&gt;
-&lt;p&gt;The AP2112 is CMOS process low dropout linear regulator with enable function, the regulator delivers a guaranteed 600mA (min.) continuous load current.&lt;/p&gt;
-&lt;p&gt;Features&lt;br&gt;
-&lt;ul&gt;
-&lt;li&gt;Output Voltage Accuracy: ±1.5% &lt;/li&gt;
-&lt;li&gt;Output Current: 600mA (Min.) &lt;/li&gt;
-&lt;li&gt;Foldback Short Current Protection: 50mA &lt;/li&gt;
-&lt;li&gt;Enable Function to Turn ON/OFF VOUT&lt;/li&gt;
-&lt;li&gt;Low Dropout Voltage (3.3V): 250mV (Typ.) @IOUT=600mA &lt;/li&gt;
-&lt;li&gt;Excellent Load Regulation: 0.2%/A (Typ.) &lt;/li&gt;
-&lt;li&gt;Excellent Line Regulation: 0.02%/V (Typ.) &lt;/li&gt;
-&lt;li&gt;Low Quiescent Current: 55μA (Typ.)&lt;/li&gt;
-&lt;li&gt;Low Standby Current: 0.01μA (Typ.)&lt;/li&gt;
-&lt;li&gt;Low Output Noise: 50μVRMS &lt;/li&gt;
-&lt;li&gt;PSRR: 100Hz -65dB, 1kHz -65dB &lt;/li&gt;
-&lt;li&gt; OTSD Protection &lt;/li&gt;
-&lt;li&gt;Stable  with  1.0μF Flexible Cap: Ceramic, Tantalum and Aluminum Electrolytic &lt;/li&gt;
-&lt;li&gt;Operation Temperature Range: -40°C to 85°C &lt;/li&gt;
-&lt;li&gt;ESD: MM 400V, HBM 4000V&lt;/li&gt;
-&lt;/ul&gt;
-&lt;/p&gt;</description>
-<gates>
-<gate name="G$1" symbol="V-REG-LDO_NO-BP" x="0" y="0"/>
-</gates>
-<devices>
-<device name="K-3.3V" package="SOT23-5">
-<connects>
-<connect gate="G$1" pin="EN" pad="3"/>
-<connect gate="G$1" pin="GND" pad="2"/>
-<connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="NC" pad="4"/>
-<connect gate="G$1" pin="OUT" pad="5"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="VREG-12457"/>
-<attribute name="VALUE" value="3.3V"/>
-</technology>
 </technologies>
 </device>
 </devices>
@@ -1722,508 +1596,1113 @@ CONN_04
 </deviceset>
 </devicesets>
 </library>
-<library name="SparkFun-Resistors" urn="urn:adsk.eagle:library:532">
-<description>&lt;h3&gt;SparkFun Resistors&lt;/h3&gt;
-This library contains resistors. Reference designator:R. 
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
+<library name="rc" urn="urn:adsk.eagle:library:2539423">
 <packages>
-<package name="AXIAL-0.3" urn="urn:adsk.eagle:footprint:39622/1" library_version="1">
-<description>&lt;h3&gt;AXIAL-0.3&lt;/h3&gt;
-&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.&lt;/p&gt;</description>
-<wire x1="-2.54" y1="0.762" x2="2.54" y2="0.762" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0.762" x2="2.54" y2="0" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0" x2="2.54" y2="-0.762" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-0.762" x2="-2.54" y2="-0.762" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="-0.762" x2="-2.54" y2="0" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="0" x2="-2.54" y2="0.762" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.2032" layer="21"/>
-<pad name="P$1" x="-3.81" y="0" drill="0.9" diameter="1.8796"/>
-<pad name="P$2" x="3.81" y="0" drill="0.9" diameter="1.8796"/>
-<text x="0" y="1.016" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-1.016" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+<package name="C0603" urn="urn:adsk.eagle:footprint:2539424/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="2" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<wire x1="-1.125" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
 </package>
-<package name="AXIAL-0.3-KIT" urn="urn:adsk.eagle:footprint:39623/1" library_version="1">
-<description>&lt;h3&gt;AXIAL-0.3-KIT&lt;/h3&gt;
-&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.&lt;/p&gt;
-&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of the AXIAL-0.3 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;</description>
-<wire x1="-2.54" y1="1.27" x2="2.54" y2="1.27" width="0.254" layer="21"/>
-<wire x1="2.54" y1="1.27" x2="2.54" y2="0" width="0.254" layer="21"/>
-<wire x1="2.54" y1="0" x2="2.54" y2="-1.27" width="0.254" layer="21"/>
-<wire x1="2.54" y1="-1.27" x2="-2.54" y2="-1.27" width="0.254" layer="21"/>
-<wire x1="-2.54" y1="-1.27" x2="-2.54" y2="0" width="0.254" layer="21"/>
-<wire x1="-2.54" y1="0" x2="-2.54" y2="1.27" width="0.254" layer="21"/>
-<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.254" layer="21"/>
-<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.254" layer="21"/>
-<pad name="P$1" x="-3.81" y="0" drill="1.016" diameter="2.032" stop="no"/>
-<pad name="P$2" x="3.81" y="0" drill="1.016" diameter="2.032" stop="no"/>
-<text x="0" y="1.524" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.524" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<polygon width="0.127" layer="30">
-<vertex x="3.8201" y="-0.9449" curve="-90"/>
-<vertex x="2.8652" y="-0.0152" curve="-90.011749"/>
-<vertex x="3.8176" y="0.9602" curve="-90"/>
-<vertex x="4.7676" y="-0.0178" curve="-90.024193"/>
+<package name="C0402" urn="urn:adsk.eagle:footprint:2539428/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.4064" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+</package>
+<package name="C0805" urn="urn:adsk.eagle:footprint:2539427/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<smd name="2" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<wire x1="-1.65" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
+<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="C1206" urn="urn:adsk.eagle:footprint:2539426/1" library_version="103" library_locally_modified="yes">
+<smd name="P$1" x="-1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<smd name="P$2" x="1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-2.2" y1="1" x2="2.2" y2="1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="1" x2="2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="-1" x2="-2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="-2.2" y1="-1" x2="-2.2" y2="1" width="0.15" layer="21"/>
+</package>
+<package name="C1210" urn="urn:adsk.eagle:footprint:2539425/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-1.55" y="0" dx="0.9" dy="2.5" layer="1"/>
+<smd name="2" x="1.55" y="0" dx="0.9" dy="2.5" layer="1"/>
+<text x="0" y="0" size="0.6" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-2.2" y1="1.45" x2="-2.2" y2="-1.45" width="0.15" layer="21"/>
+<wire x1="-2.2" y1="-1.45" x2="2.2" y2="-1.45" width="0.15" layer="21"/>
+<wire x1="2.2" y1="-1.45" x2="2.2" y2="1.45" width="0.15" layer="21"/>
+<wire x1="2.2" y1="1.45" x2="-2.2" y2="1.45" width="0.15" layer="21"/>
+</package>
+<package name="C1812" urn="urn:adsk.eagle:footprint:2539442/1" library_version="103" library_locally_modified="yes">
+<smd name="P$1" x="-2" y="0" dx="3.45" dy="1.9" layer="1" rot="R90"/>
+<smd name="P$2" x="2" y="0" dx="3.45" dy="1.9" layer="1" rot="R90"/>
+<wire x1="-3.15" y1="1.9" x2="3.15" y2="1.9" width="0.1" layer="21"/>
+<wire x1="3.15" y1="1.9" x2="3.15" y2="-1.9" width="0.1" layer="21"/>
+<wire x1="3.15" y1="-1.9" x2="-3.15" y2="-1.9" width="0.1" layer="21"/>
+<wire x1="-3.15" y1="-1.9" x2="-3.15" y2="1.9" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.8" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="C1206_COMPACT" urn="urn:adsk.eagle:footprint:4600577/1" library_version="103" library_locally_modified="yes">
+<smd name="P$1" x="-1.35" y="0" dx="0.9" dy="1.6" layer="1"/>
+<smd name="P$2" x="1.35" y="0" dx="0.9" dy="1.6" layer="1"/>
+<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-1.95" y1="0.95" x2="1.95" y2="0.95" width="0.1" layer="21"/>
+<wire x1="1.95" y1="0.95" x2="1.95" y2="-0.95" width="0.1" layer="21"/>
+<wire x1="1.95" y1="-0.95" x2="-1.95" y2="-0.95" width="0.1" layer="21"/>
+<wire x1="-1.95" y1="-0.95" x2="-1.95" y2="0.95" width="0.1" layer="21"/>
+</package>
+<package name="C0201" urn="urn:adsk.eagle:footprint:10810349/3" library_version="103" library_locally_modified="yes">
+<description>Perfect 0201 for Reflow Soldering
+&lt;p&gt;0.024" L x 0.012" W (0.60mm x 0.30mm)</description>
+<smd name="1" x="0" y="0.275" dx="0.35" dy="0.25" layer="1"/>
+<smd name="2" x="0" y="-0.275" dx="0.35" dy="0.25" layer="1"/>
+<text x="0" y="0" size="0.35" layer="25" font="vector" ratio="15" rot="R90" align="center">&gt;NAME</text>
+<polygon width="0.005" layer="51">
+<vertex x="-0.15" y="-0.3"/>
+<vertex x="0.15" y="-0.3"/>
+<vertex x="0.15" y="0.3"/>
+<vertex x="-0.15" y="0.3"/>
 </polygon>
-<polygon width="0.127" layer="29">
-<vertex x="3.8176" y="-0.4369" curve="-90.012891"/>
-<vertex x="3.3731" y="-0.0127" curve="-90"/>
-<vertex x="3.8176" y="0.4546" curve="-90"/>
-<vertex x="4.2595" y="-0.0025" curve="-90.012967"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="-3.8075" y="-0.9525" curve="-90"/>
-<vertex x="-4.7624" y="-0.0228" curve="-90.011749"/>
-<vertex x="-3.81" y="0.9526" curve="-90"/>
-<vertex x="-2.86" y="-0.0254" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-3.81" y="-0.4445" curve="-90.012891"/>
-<vertex x="-4.2545" y="-0.0203" curve="-90"/>
-<vertex x="-3.81" y="0.447" curve="-90"/>
-<vertex x="-3.3681" y="-0.0101" curve="-90.012967"/>
-</polygon>
+<wire x1="-0.3" y1="0.525" x2="0.3" y2="0.525" width="0.1" layer="21"/>
+<wire x1="0.3" y1="0.525" x2="0.3" y2="-0.525" width="0.1" layer="21"/>
+<wire x1="0.3" y1="-0.525" x2="-0.3" y2="-0.525" width="0.1" layer="21"/>
+<wire x1="-0.3" y1="-0.525" x2="-0.3" y2="0.525" width="0.1" layer="21"/>
 </package>
-<package name="0603" urn="urn:adsk.eagle:footprint:39615/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 1608 (0603) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-1.6" y1="0.7" x2="1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="0.7" x2="1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="-0.7" x2="-1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="-1.6" y1="-0.7" x2="-1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
-<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
-<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<text x="0" y="0.762" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.762" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
-<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+<package name="C2220" urn="urn:adsk.eagle:footprint:11093137/1" library_version="103" library_locally_modified="yes">
+<smd name="P$1" x="-2.6" y="0" dx="1.2" dy="5.2" layer="1"/>
+<smd name="P$2" x="2.6" y="0" dx="1.2" dy="5.2" layer="1"/>
+<wire x1="-3.4" y1="2.8" x2="3.4" y2="2.8" width="0.1" layer="21"/>
+<wire x1="3.4" y1="2.8" x2="3.4" y2="-2.8" width="0.1" layer="21"/>
+<wire x1="3.4" y1="-2.8" x2="-3.4" y2="-2.8" width="0.1" layer="21"/>
+<wire x1="-3.4" y1="-2.8" x2="-3.4" y2="2.8" width="0.1" layer="21"/>
+<text x="0" y="0" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
-<package name="AXIAL-0.3EZ" urn="urn:adsk.eagle:footprint:39624/1" library_version="1">
-<description>This is the "EZ" version of the standard .3" spaced resistor package.&lt;br&gt;
-It has a reduced top mask to make it harder to install upside-down.</description>
-<wire x1="-2.54" y1="0.762" x2="2.54" y2="0.762" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0.762" x2="2.54" y2="0" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0" x2="2.54" y2="-0.762" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-0.762" x2="-2.54" y2="-0.762" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="-0.762" x2="-2.54" y2="0" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="0" x2="-2.54" y2="0.762" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.2032" layer="21"/>
-<pad name="P$1" x="-3.81" y="0" drill="0.9" diameter="1.8796" stop="no"/>
-<pad name="P$2" x="3.81" y="0" drill="0.9" diameter="1.8796" stop="no"/>
-<text x="0" y="1.016" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-1.016" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-<circle x="-3.81" y="0" radius="0.508" width="0" layer="29"/>
-<circle x="3.81" y="0" radius="0.523634375" width="0" layer="29"/>
-<circle x="-3.81" y="0" radius="1.02390625" width="0" layer="30"/>
-<circle x="3.81" y="0" radius="1.04726875" width="0" layer="30"/>
+<package name="C2220-STACKED" urn="urn:adsk.eagle:footprint:11093138/1" library_version="103" library_locally_modified="yes">
+<smd name="P$1" x="-2.6" y="0" dx="1.2" dy="5.2" layer="1"/>
+<smd name="P$2" x="2.6" y="0" dx="1.2" dy="5.2" layer="1"/>
+<wire x1="-3.4" y1="2.8" x2="3.4" y2="2.8" width="0.1" layer="21"/>
+<wire x1="3.4" y1="2.8" x2="3.4" y2="-2.8" width="0.1" layer="21"/>
+<wire x1="3.4" y1="-2.8" x2="-3.4" y2="-2.8" width="0.1" layer="21"/>
+<wire x1="-3.4" y1="-2.8" x2="-3.4" y2="2.8" width="0.1" layer="21"/>
+<text x="0" y="0" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
-<package name="AXIAL-0.1" urn="urn:adsk.eagle:footprint:39620/1" library_version="1">
-<description>&lt;h3&gt;AXIAL-0.1&lt;/h3&gt;
-&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.&lt;/p&gt;</description>
-<wire x1="0" y1="-0.762" x2="0" y2="0" width="0.2032" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="0.762" width="0.2032" layer="21"/>
-<wire x1="0.254" y1="0" x2="0" y2="0" width="0.2032" layer="21"/>
-<wire x1="0" y1="0" x2="-0.254" y2="0" width="0.2032" layer="21"/>
-<pad name="P$1" x="-1.27" y="0" drill="0.9" diameter="1.8796"/>
-<pad name="P$2" x="1.27" y="0" drill="0.9" diameter="1.8796"/>
-<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-1.143" size="0.6096" layer="21" font="vector" ratio="20" align="top-center">&gt;Value</text>
+<package name="R0603" urn="urn:adsk.eagle:footprint:2539436/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="2" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<wire x1="-1.125" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
 </package>
-<package name="AXIAL-0.1-KIT" urn="urn:adsk.eagle:footprint:39621/1" library_version="1">
-<description>&lt;h3&gt;AXIAL-0.1-KIT&lt;/h3&gt;
-&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.&lt;/p&gt;
-&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of the AXIAL-0.1 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;</description>
-<wire x1="0" y1="-0.762" x2="0" y2="0" width="0.2032" layer="21"/>
-<wire x1="0" y1="0" x2="0" y2="0.762" width="0.2032" layer="21"/>
-<wire x1="0.254" y1="0" x2="0" y2="0" width="0.2032" layer="21"/>
-<wire x1="0" y1="0" x2="-0.254" y2="0" width="0.2032" layer="21"/>
-<pad name="P$1" x="-1.27" y="0" drill="0.9" diameter="1.8796" stop="no"/>
-<pad name="P$2" x="1.27" y="0" drill="0.9" diameter="1.8796" stop="no"/>
-<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-1.143" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-<circle x="-1.27" y="0" radius="0.4572" width="0" layer="29"/>
-<circle x="-1.27" y="0" radius="1.016" width="0" layer="30"/>
-<circle x="1.27" y="0" radius="1.016" width="0" layer="30"/>
-<circle x="-1.27" y="0" radius="0.4572" width="0" layer="29"/>
-<circle x="1.27" y="0" radius="0.4572" width="0" layer="29"/>
+<package name="R0402" urn="urn:adsk.eagle:footprint:2539434/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+</package>
+<package name="R0805" urn="urn:adsk.eagle:footprint:2539435/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<smd name="2" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<wire x1="-1.65" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
+<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="R1206" urn="urn:adsk.eagle:footprint:2539441/1" library_version="103" library_locally_modified="yes">
+<smd name="P$1" x="-1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<smd name="P$2" x="1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-2.2" y1="1" x2="2.2" y2="1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="1" x2="2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="-1" x2="-2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="-2.2" y1="-1" x2="-2.2" y2="1" width="0.15" layer="21"/>
+</package>
+<package name="R2512" urn="urn:adsk.eagle:footprint:1040086/1" library_version="103" library_locally_modified="yes">
+<description>http://www.resistor.com/assets/pdf/2512std.pdf</description>
+<smd name="1" x="-3.25" y="0" dx="3.2" dy="1.25" layer="1" rot="R90"/>
+<smd name="2" x="3.25" y="0" dx="3.2" dy="1.25" layer="1" rot="R90"/>
+<wire x1="-4.05" y1="1.75" x2="4.05" y2="1.75" width="0.1" layer="21"/>
+<wire x1="4.05" y1="1.75" x2="4.05" y2="-1.75" width="0.1" layer="21"/>
+<wire x1="4.05" y1="-1.75" x2="-4.05" y2="-1.75" width="0.1" layer="21"/>
+<wire x1="-4.05" y1="-1.75" x2="-4.05" y2="1.75" width="0.1" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="R2010" urn="urn:adsk.eagle:footprint:26916225/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-2.5" y="0" dx="1.5" dy="3.4" layer="1"/>
+<smd name="2" x="2.5" y="0" dx="1.5" dy="3.4" layer="1"/>
+<wire x1="3.45" y1="-1.9" x2="3.45" y2="1.9" width="0.15" layer="21"/>
+<wire x1="3.45" y1="1.9" x2="-3.45" y2="1.9" width="0.15" layer="21"/>
+<wire x1="-3.45" y1="1.9" x2="-3.45" y2="-1.9" width="0.15" layer="21"/>
+<wire x1="-3.45" y1="-1.9" x2="3.45" y2="-1.9" width="0.15" layer="21"/>
+<text x="0" y="0" size="1.3" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="-2.7" size="1.3" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="LED0603" urn="urn:adsk.eagle:footprint:2539448/3" library_version="103" library_locally_modified="yes">
+<smd name="A" x="0.725" y="0" dx="0.6" dy="0.9" layer="1" rot="R180"/>
+<smd name="C" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1" rot="R180"/>
+<wire x1="1.125" y1="-0.55" x2="-0.25" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="0.55" x2="-0.25" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="-0.55" x2="-0.25" y2="0.55" width="0.1" layer="21"/>
+<wire x1="-0.25" y1="0" x2="0.3" y2="0.55" width="0.1" layer="51"/>
+<wire x1="0.3" y1="0.55" x2="0.3" y2="-0.55" width="0.1" layer="51"/>
+<wire x1="0.3" y1="-0.55" x2="-0.25" y2="0" width="0.1" layer="51"/>
+<wire x1="-0.25" y1="0.55" x2="-0.25" y2="-0.55" width="0.1" layer="51"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" rot="R180" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="LED0402" urn="urn:adsk.eagle:footprint:2539447/2" library_version="103" library_locally_modified="yes">
+<smd name="A" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="C" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.4064" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.1" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="0.45" x2="0.1" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.1" y1="0" x2="-0.35" y2="0.45" width="0.1" layer="51"/>
+<wire x1="-0.35" y1="0.45" x2="-0.35" y2="-0.45" width="0.1" layer="51"/>
+<wire x1="-0.35" y1="-0.45" x2="0.1" y2="0" width="0.1" layer="51"/>
+<wire x1="0.1" y1="0.45" x2="0.1" y2="-0.45" width="0.1" layer="51"/>
+</package>
+<package name="LED0805" urn="urn:adsk.eagle:footprint:2539449/1" library_version="103" library_locally_modified="yes">
+<smd name="A" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<smd name="C" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<wire x1="-1.65" y1="0.85" x2="0.4" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.4" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="-0.85" x2="0.4" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="0.4" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.4" y1="0.85" x2="0.4" y2="-0.85" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="LED1206" urn="urn:adsk.eagle:footprint:2539450/1" library_version="103" library_locally_modified="yes">
+<smd name="A" x="-1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<smd name="C" x="1.55" y="0" dx="0.9" dy="1.6" layer="1"/>
+<text x="0" y="0" size="0.762" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<wire x1="-2.2" y1="1" x2="0.9" y2="1" width="0.15" layer="21"/>
+<wire x1="0.9" y1="1" x2="2.2" y2="1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="1" x2="2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="2.2" y1="-1" x2="0.9" y2="-1" width="0.15" layer="21"/>
+<wire x1="0.9" y1="-1" x2="-2.2" y2="-1" width="0.15" layer="21"/>
+<wire x1="-2.2" y1="-1" x2="-2.2" y2="1" width="0.15" layer="21"/>
+<wire x1="0.9" y1="1" x2="0.9" y2="-1" width="0.15" layer="21"/>
+</package>
+<package name="LED3MM" urn="urn:adsk.eagle:footprint:24459248/1" locally_modified="yes" library_version="103" library_locally_modified="yes">
+<description>&lt;B&gt;LED&lt;/B&gt;&lt;p&gt;
+3 mm, round</description>
+<wire x1="1.5748" y1="-1.27" x2="1.5748" y2="1.27" width="0.254" layer="51"/>
+<wire x1="-1.524" y1="0" x2="-1.1708" y2="0.9756" width="0.1524" layer="51" curve="-39.80361"/>
+<wire x1="-1.524" y1="0" x2="-1.1391" y2="-1.0125" width="0.1524" layer="51" curve="41.633208"/>
+<wire x1="1.1571" y1="0.9918" x2="1.524" y2="0" width="0.1524" layer="51" curve="-40.601165"/>
+<wire x1="1.1708" y1="-0.9756" x2="1.524" y2="0" width="0.1524" layer="51" curve="39.80361"/>
+<wire x1="0" y1="1.524" x2="1.2401" y2="0.8858" width="0.1524" layer="21" curve="-54.461337"/>
+<wire x1="-1.2192" y1="0.9144" x2="0" y2="1.524" width="0.1524" layer="21" curve="-53.130102"/>
+<wire x1="0" y1="-1.524" x2="1.203" y2="-0.9356" width="0.1524" layer="21" curve="52.126876"/>
+<wire x1="-1.203" y1="-0.9356" x2="0" y2="-1.524" width="0.1524" layer="21" curve="52.126876"/>
+<wire x1="-0.635" y1="0" x2="0" y2="0.635" width="0.1524" layer="51" curve="-90"/>
+<wire x1="-1.016" y1="0" x2="0" y2="1.016" width="0.1524" layer="51" curve="-90"/>
+<wire x1="0" y1="-0.635" x2="0.635" y2="0" width="0.1524" layer="51" curve="90"/>
+<wire x1="0" y1="-1.016" x2="1.016" y2="0" width="0.1524" layer="51" curve="90"/>
+<wire x1="0" y1="2.032" x2="1.561" y2="1.3009" width="0.254" layer="21" curve="-50.193108"/>
+<wire x1="-1.7929" y1="0.9562" x2="0" y2="2.032" width="0.254" layer="21" curve="-61.926949"/>
+<wire x1="0" y1="-2.032" x2="1.5512" y2="-1.3126" width="0.254" layer="21" curve="49.763022"/>
+<wire x1="-1.7643" y1="-1.0082" x2="0" y2="-2.032" width="0.254" layer="21" curve="60.255215"/>
+<wire x1="-2.032" y1="0" x2="-1.7891" y2="0.9634" width="0.254" layer="51" curve="-28.301701"/>
+<wire x1="-2.032" y1="0" x2="-1.7306" y2="-1.065" width="0.254" layer="51" curve="31.60822"/>
+<pad name="A" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
+<pad name="K" x="1.27" y="0" drill="0.8128" shape="octagon"/>
+<text x="0" y="2.921" size="1.27" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="-2.6" y="0" size="1.5" layer="21" font="vector" ratio="15" align="center">+</text>
+</package>
+<package name="LED4014" urn="urn:adsk.eagle:footprint:27229817/1" library_version="103" library_locally_modified="yes">
+<smd name="A" x="-1.7" y="0" dx="1.04" dy="1.1" layer="1" rot="R90"/>
+<smd name="C" x="0.81" y="0" dx="2.92" dy="1.04" layer="1"/>
+<wire x1="-2" y1="-0.725" x2="-2" y2="0.725" width="0.1" layer="51"/>
+<wire x1="-2" y1="-0.725" x2="2" y2="-0.725" width="0.1" layer="51"/>
+<wire x1="2" y1="-0.725" x2="2" y2="0.725" width="0.1" layer="51"/>
+<wire x1="2" y1="0.725" x2="-2" y2="0.725" width="0.1" layer="51"/>
+<wire x1="-2" y1="0.675" x2="-2" y2="0.725" width="0.1" layer="21"/>
+<wire x1="-2" y1="0.725" x2="2" y2="0.725" width="0.1" layer="21"/>
+<wire x1="2" y1="0.725" x2="2" y2="0.675" width="0.1" layer="21"/>
+<wire x1="2" y1="-0.675" x2="2" y2="-0.725" width="0.1" layer="21"/>
+<wire x1="2" y1="-0.725" x2="-2" y2="-0.725" width="0.1" layer="21"/>
+<wire x1="-2" y1="-0.725" x2="-2" y2="-0.675" width="0.1" layer="21"/>
+<text x="0" y="0" size="1" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<rectangle x1="1.35" y1="-0.75" x2="1.5" y2="0.75" layer="51"/>
+</package>
+<package name="LED3014" urn="urn:adsk.eagle:footprint:27230108/1" library_version="103" library_locally_modified="yes">
+<smd name="C" x="-1.4" y="0" dx="1.4" dy="1.4" layer="1"/>
+<smd name="A" x="1.42" y="0" dx="1.4" dy="1.4" layer="1"/>
+<wire x1="-1.5" y1="-0.7" x2="-1.5" y2="0.7" width="0.1" layer="51"/>
+<wire x1="-1.5" y1="0.7" x2="0.3" y2="0.7" width="0.1" layer="51"/>
+<wire x1="0.3" y1="0.7" x2="1.5" y2="0.7" width="0.1" layer="51"/>
+<wire x1="1.5" y1="0.7" x2="1.5" y2="-0.7" width="0.1" layer="51"/>
+<wire x1="1.5" y1="-0.7" x2="0.3" y2="-0.7" width="0.1" layer="51"/>
+<wire x1="0.3" y1="-0.7" x2="-1.5" y2="-0.7" width="0.1" layer="51"/>
+<wire x1="-0.6" y1="0.7" x2="0.6" y2="0.7" width="0.1" layer="21"/>
+<wire x1="0.6" y1="-0.7" x2="-0.6" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="0.3" y1="0.7" x2="0.3" y2="-0.7" width="0.1" layer="51"/>
+<wire x1="0.3" y1="-0.7" x2="-0.4" y2="0" width="0.1" layer="51"/>
+<wire x1="-0.4" y1="0" x2="0.3" y2="0.7" width="0.1" layer="51"/>
+<wire x1="-0.4" y1="-0.5" x2="-0.4" y2="0.5" width="0.1" layer="51"/>
+<text x="0" y="1.1" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+</package>
+<package name="L0402" urn="urn:adsk.eagle:footprint:5347942/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.0508" layer="39"/>
+<wire x1="-0.9" y1="0.45" x2="0.9" y2="0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="0.9" y1="-0.45" x2="-0.9" y2="-0.45" width="0.1" layer="21"/>
+<wire x1="-0.9" y1="-0.45" x2="-0.9" y2="0.45" width="0.1" layer="21"/>
+</package>
+<package name="L0603" urn="urn:adsk.eagle:footprint:8766558/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<smd name="2" x="0.725" y="0" dx="0.6" dy="0.9" layer="1"/>
+<wire x1="-1.125" y1="0.55" x2="1.125" y2="0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="0.55" x2="1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="1.125" y1="-0.55" x2="-1.125" y2="-0.55" width="0.1" layer="21"/>
+<wire x1="-1.125" y1="-0.55" x2="-1.125" y2="0.55" width="0.1" layer="21"/>
+<text x="0" y="0" size="0.5" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="0" y="1" size="0.5" layer="27" font="vector" ratio="15" align="center">&gt;VALUE</text>
+</package>
+<package name="L0805" urn="urn:adsk.eagle:footprint:32710305/1" library_version="103" library_locally_modified="yes">
+<smd name="1" x="-1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<smd name="2" x="1" y="0" dx="0.9" dy="1.3" layer="1"/>
+<wire x1="-1.65" y1="0.85" x2="1.65" y2="0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="0.85" x2="1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.65" y1="-0.85" x2="-1.65" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.65" y1="-0.85" x2="-1.65" y2="0.85" width="0.127" layer="21"/>
+<text x="0" y="0" size="0.635" layer="25" font="vector" ratio="15" align="center">&gt;NAME</text>
 </package>
 </packages>
 <packages3d>
-<package3d name="AXIAL-0.3" urn="urn:adsk.eagle:package:39658/1" type="box" library_version="1">
-<description>AXIAL-0.3
-Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.</description>
+<package3d name="C0603" urn="urn:adsk.eagle:package:2539457/2" type="model" library_version="103" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="AXIAL-0.3"/>
+<packageinstance name="C0603"/>
 </packageinstances>
 </package3d>
-<package3d name="AXIAL-0.3-KIT" urn="urn:adsk.eagle:package:39661/1" type="box" library_version="1">
-<description>AXIAL-0.3-KIT
-Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.
-Warning: This is the KIT version of the AXIAL-0.3 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.</description>
+<package3d name="C0402" urn="urn:adsk.eagle:package:2539461/2" type="model" library_version="103" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="AXIAL-0.3-KIT"/>
+<packageinstance name="C0402"/>
 </packageinstances>
 </package3d>
-<package3d name="0603" urn="urn:adsk.eagle:package:39650/1" type="box" library_version="1">
-<description>Generic 1608 (0603) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
+<package3d name="C0805" urn="urn:adsk.eagle:package:2539460/3" type="model" library_version="103" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="0603"/>
+<packageinstance name="C0805"/>
 </packageinstances>
 </package3d>
-<package3d name="AXIAL-0.3EZ" urn="urn:adsk.eagle:package:39655/1" type="box" library_version="1">
-<description>This is the "EZ" version of the standard .3" spaced resistor package.
-It has a reduced top mask to make it harder to install upside-down.</description>
+<package3d name="C1206" urn="urn:adsk.eagle:package:2539459/2" type="model" library_version="103" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="AXIAL-0.3EZ"/>
+<packageinstance name="C1206"/>
 </packageinstances>
 </package3d>
-<package3d name="AXIAL-0.1" urn="urn:adsk.eagle:package:39656/1" type="box" library_version="1">
-<description>AXIAL-0.1
-Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.</description>
+<package3d name="C1210" urn="urn:adsk.eagle:package:2539458/2" type="model" library_version="103" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="AXIAL-0.1"/>
+<packageinstance name="C1210"/>
 </packageinstances>
 </package3d>
-<package3d name="AXIAL-0.1-KIT" urn="urn:adsk.eagle:package:39653/1" type="box" library_version="1">
-<description>AXIAL-0.1-KIT
-Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.
-Warning: This is the KIT version of the AXIAL-0.1 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.</description>
+<package3d name="C1812" urn="urn:adsk.eagle:package:2539465/2" type="model" library_version="103" library_locally_modified="yes">
 <packageinstances>
-<packageinstance name="AXIAL-0.1-KIT"/>
+<packageinstance name="C1812"/>
+</packageinstances>
+</package3d>
+<package3d name="C1206_COMPACT" urn="urn:adsk.eagle:package:4600578/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="C1206_COMPACT"/>
+</packageinstances>
+</package3d>
+<package3d name="C0201" urn="urn:adsk.eagle:package:10810351/4" type="model" library_version="103" library_locally_modified="yes">
+<description>Perfect 0201 for Reflow Soldering
+&lt;p&gt;0.024" L x 0.012" W (0.60mm x 0.30mm)</description>
+<packageinstances>
+<packageinstance name="C0201"/>
+</packageinstances>
+</package3d>
+<package3d name="C2220" urn="urn:adsk.eagle:package:11093139/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="C2220"/>
+</packageinstances>
+</package3d>
+<package3d name="C2220-STACKED" urn="urn:adsk.eagle:package:11093140/1" type="box" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="C2220-STACKED"/>
+</packageinstances>
+</package3d>
+<package3d name="R0603" urn="urn:adsk.eagle:package:2539454/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R0603"/>
+</packageinstances>
+</package3d>
+<package3d name="R0402" urn="urn:adsk.eagle:package:2539456/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R0402"/>
+</packageinstances>
+</package3d>
+<package3d name="R0805" urn="urn:adsk.eagle:package:2539455/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R0805"/>
+</packageinstances>
+</package3d>
+<package3d name="R1206" urn="urn:adsk.eagle:package:2539464/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R1206"/>
+</packageinstances>
+</package3d>
+<package3d name="R2512" urn="urn:adsk.eagle:package:4855216/2" type="model" library_version="103" library_locally_modified="yes">
+<description>http://www.resistor.com/assets/pdf/2512std.pdf</description>
+<packageinstances>
+<packageinstance name="R2512"/>
+</packageinstances>
+</package3d>
+<package3d name="R2010" urn="urn:adsk.eagle:package:26916226/1" type="box" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="R2010"/>
+</packageinstances>
+</package3d>
+<package3d name="LED0603" urn="urn:adsk.eagle:package:2539471/4" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="LED0603"/>
+</packageinstances>
+</package3d>
+<package3d name="LED0402" urn="urn:adsk.eagle:package:2539470/3" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="LED0402"/>
+</packageinstances>
+</package3d>
+<package3d name="LED0805" urn="urn:adsk.eagle:package:2539472/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="LED0805"/>
+</packageinstances>
+</package3d>
+<package3d name="LED1206" urn="urn:adsk.eagle:package:2539473/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="LED1206"/>
+</packageinstances>
+</package3d>
+<package3d name="LED3MM" urn="urn:adsk.eagle:package:24459249/2" type="model" library_version="103" library_locally_modified="yes">
+<description>&lt;B&gt;LED&lt;/B&gt;&lt;p&gt;
+3 mm, round</description>
+<packageinstances>
+<packageinstance name="LED3MM"/>
+</packageinstances>
+</package3d>
+<package3d name="LED4014" urn="urn:adsk.eagle:package:27229818/1" type="box" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="LED4014"/>
+</packageinstances>
+</package3d>
+<package3d name="LED3014" urn="urn:adsk.eagle:package:27230109/1" type="box" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="LED3014"/>
+</packageinstances>
+</package3d>
+<package3d name="L0402" urn="urn:adsk.eagle:package:5347945/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="L0402"/>
+</packageinstances>
+</package3d>
+<package3d name="L0603" urn="urn:adsk.eagle:package:8766559/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="L0603"/>
+</packageinstances>
+</package3d>
+<package3d name="L0805" urn="urn:adsk.eagle:package:32710307/2" type="model" library_version="103" library_locally_modified="yes">
+<packageinstances>
+<packageinstance name="L0805"/>
 </packageinstances>
 </package3d>
 </packages3d>
 <symbols>
-<symbol name="RESISTOR" urn="urn:adsk.eagle:symbol:39614/1" library_version="1">
-<wire x1="-2.54" y1="0" x2="-2.159" y2="1.016" width="0.1524" layer="94"/>
-<wire x1="-2.159" y1="1.016" x2="-1.524" y2="-1.016" width="0.1524" layer="94"/>
-<wire x1="-1.524" y1="-1.016" x2="-0.889" y2="1.016" width="0.1524" layer="94"/>
-<wire x1="-0.889" y1="1.016" x2="-0.254" y2="-1.016" width="0.1524" layer="94"/>
-<wire x1="-0.254" y1="-1.016" x2="0.381" y2="1.016" width="0.1524" layer="94"/>
-<wire x1="0.381" y1="1.016" x2="1.016" y2="-1.016" width="0.1524" layer="94"/>
-<wire x1="1.016" y1="-1.016" x2="1.651" y2="1.016" width="0.1524" layer="94"/>
-<wire x1="1.651" y1="1.016" x2="2.286" y2="-1.016" width="0.1524" layer="94"/>
-<wire x1="2.286" y1="-1.016" x2="2.54" y2="0" width="0.1524" layer="94"/>
-<text x="0" y="1.524" size="1.778" layer="95" font="vector" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.524" size="1.778" layer="96" font="vector" align="top-center">&gt;VALUE</text>
+<symbol name="C" urn="urn:adsk.eagle:symbol:2539433/4" library_version="103" library_locally_modified="yes">
+<wire x1="-2.54" y1="0" x2="-0.762" y2="0" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="0" x2="0.762" y2="0" width="0.1524" layer="94"/>
+<text x="1.27" y="-0.889" size="1.27" layer="95" font="vector" align="center-left">&gt;NAME</text>
+<text x="-1.27" y="0.254" size="0.762" layer="96" font="vector" align="bottom-right">&gt;VALUE</text>
+<text x="-2.032" y="-0.508" size="0.508" layer="97" font="vector" rot="R180" align="center">&gt;PACKAGE</text>
+<text x="1.016" y="0.508" size="0.508" layer="97" font="vector" align="center-left">&gt;VOLTAGE</text>
+<text x="0" y="2.54" size="0.508" layer="97" font="vector" align="center">&gt;allocated</text>
+<rectangle x1="-1.524" y1="-0.254" x2="2.54" y2="0.254" layer="94" rot="R90"/>
+<rectangle x1="-2.54" y1="-0.254" x2="1.524" y2="0.254" layer="94" rot="R90"/>
+<pin name="1" x="-2.54" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+<pin name="2" x="2.54" y="0" visible="off" length="point" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="R" urn="urn:adsk.eagle:symbol:2539432/5" library_version="103" library_locally_modified="yes">
+<wire x1="-2.54" y1="-0.889" x2="2.54" y2="-0.889" width="0.254" layer="94"/>
+<wire x1="2.54" y1="0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
+<wire x1="2.54" y1="-0.889" x2="2.54" y2="0.889" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="-0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
+<text x="0" y="0" size="1.27" layer="95" font="vector" align="center">&gt;NAME</text>
+<text x="-0.254" y="-2.032" size="0.762" layer="96" font="vector" align="bottom-right">&gt;VALUE</text>
+<text x="-3.81" y="0.508" size="0.508" layer="95" font="vector" align="center">&gt;PACKAGE</text>
+<text x="0.254" y="-2.032" size="0.762" layer="96" font="vector">&gt;TOLERANCE</text>
+<text x="0" y="1.524" size="0.762" layer="97" font="vector" align="center">&gt;ALLOCATED</text>
 <pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
 <pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
 </symbol>
+<symbol name="LED" urn="urn:adsk.eagle:symbol:2539429/3" library_version="103" library_locally_modified="yes">
+<wire x1="-2.54" y1="1.27" x2="-2.54" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="-1.27" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="-2.54" y2="1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="1.27" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="0" y1="2.54" x2="1.524" y2="4.064" width="0.254" layer="94"/>
+<wire x1="1.524" y1="4.064" x2="0.508" y2="3.556" width="0.254" layer="94"/>
+<wire x1="1.016" y1="3.048" x2="1.524" y2="4.064" width="0.254" layer="94"/>
+<wire x1="-1.524" y1="2.54" x2="0" y2="4.064" width="0.254" layer="94"/>
+<wire x1="0" y1="4.064" x2="-1.016" y2="3.556" width="0.254" layer="94"/>
+<wire x1="-0.508" y1="3.048" x2="0" y2="4.064" width="0.254" layer="94"/>
+<pin name="A" x="-5.08" y="0" visible="off" length="short"/>
+<pin name="C" x="2.54" y="0" visible="off" length="short" rot="R180"/>
+<text x="-2.54" y="-2.54" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="-2.794" y="0.508" size="0.635" layer="96" font="vector" align="center-right">&gt;COLOR</text>
+<text x="-2.794" y="-0.508" size="0.635" layer="96" font="vector" align="center-right">&gt;PACKAGE</text>
+</symbol>
+<symbol name="L" urn="urn:adsk.eagle:symbol:5347939/2" library_version="103" library_locally_modified="yes">
+<pin name="P$1" x="-5.08" y="0" visible="off" length="point"/>
+<pin name="P$2" x="5.08" y="0" visible="off" length="point" rot="R180"/>
+<text x="0" y="-0.762" size="0.889" layer="96" font="vector" ratio="15" align="center">&gt;VALUE</text>
+<text x="0" y="1.778" size="1.27" layer="95" font="vector" ratio="15" align="center">&gt;NAME</text>
+<text x="-3.81" y="0.762" size="0.889" layer="97" font="vector" ratio="15" align="center">&gt;ALLOCATED</text>
+<wire x1="-3.048" y1="0" x2="-2.032" y2="1.016" width="0.1524" layer="94" curve="-90"/>
+<wire x1="-2.032" y1="1.016" x2="-1.016" y2="0" width="0.1524" layer="94" curve="-90"/>
+<wire x1="-1.016" y1="0" x2="0" y2="1.016" width="0.1524" layer="94" curve="-90"/>
+<wire x1="0" y1="1.016" x2="1.016" y2="0" width="0.1524" layer="94" curve="-90"/>
+<wire x1="1.016" y1="0" x2="2.032" y2="1.016" width="0.1524" layer="94" curve="-90"/>
+<wire x1="2.032" y1="1.016" x2="3.048" y2="0" width="0.1524" layer="94" curve="-90"/>
+<wire x1="-3.048" y1="0" x2="-5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="3.048" y1="0" x2="5.08" y2="0" width="0.1524" layer="94"/>
+</symbol>
 </symbols>
 <devicesets>
-<deviceset name="10KOHM" urn="urn:adsk.eagle:component:39764/1" prefix="R" library_version="1">
-<description>&lt;h3&gt;10kΩ resistor&lt;/h3&gt;
-&lt;p&gt;A resistor is a passive two-terminal electrical component that implements electrical resistance as a circuit element. Resistors act to reduce current flow, and, at the same time, act to lower voltage levels within circuits. - Wikipedia&lt;/p&gt;</description>
+<deviceset name="C" urn="urn:adsk.eagle:component:2539479/26" prefix="C" uservalue="yes" library_version="103" library_locally_modified="yes">
 <gates>
-<gate name="G$1" symbol="RESISTOR" x="0" y="0"/>
+<gate name="G$1" symbol="C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-HORIZ-1/4W-1%" package="AXIAL-0.3">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39658/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12183" constant="no"/>
-<attribute name="VALUE" value="10k" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT-1/4W-1%" package="AXIAL-0.1">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39656/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12183"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT_KIT-1/4W-1%" package="AXIAL-0.1-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39653/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12183" constant="no"/>
-<attribute name="VALUE" value="10k" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT-1/4W-5%" package="AXIAL-0.1">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39656/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-09435"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT_KIT-1/4W-5%" package="AXIAL-0.1-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39653/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-09435"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-HORIZ-1/4W-5%" package="AXIAL-0.3">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39658/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-09435"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-HORIZ_KIT-1/4W-5%" package="AXIAL-0.3-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39661/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-09435"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-HORIZ_KIT-1/4W-1%" package="AXIAL-0.3-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39661/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12183"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT-1/6W-5%" package="AXIAL-0.1">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39656/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-08375"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT_KIT-1/6W-5%" package="AXIAL-0.1-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39653/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-08375"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-HORIZ-1/6W-5%" package="AXIAL-0.3">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39658/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-08375"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-HORIZ_KIT-1/6W-5%" package="AXIAL-0.3-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39661/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-08375"/>
-<attribute name="VALUE" value="10k"/>
-</technology>
-</technologies>
-</device>
-<device name="-0603-1/10W-1%" package="0603">
+<device name="-0402" package="C0402">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39650/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539461/2"/>
 </package3dinstances>
 <technologies>
 <technology name="">
-<attribute name="PROD_ID" value="RES-00824"/>
-<attribute name="VALUE" value="10k"/>
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0402" constant="no"/>
+<attribute name="VOLTAGE" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0805" package="C0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539460/3"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0805" constant="no"/>
+<attribute name="VOLTAGE" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1206" package="C1206">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539459/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="1206" constant="no"/>
+<attribute name="VOLTAGE" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1210" package="C1210">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539458/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="1210" constant="no"/>
+<attribute name="VOLTAGE" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0603" package="C0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539457/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0603" constant="no"/>
+<attribute name="VOLTAGE" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1812" package="C1812">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539465/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PACKAGE" value="1812" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1206_COMPACT" package="C1206_COMPACT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4600578/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PACKAGE" value="1206" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0201" package="C0201">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:10810351/4"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0201" constant="no"/>
+<attribute name="VOLTAGE" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-C2220" package="C2220">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11093139/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PACKAGE" value="2220" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-C2220-STACKED" package="C2220-STACKED">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:11093140/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PACKAGE" value="2220-STACK" constant="no"/>
 </technology>
 </technologies>
 </device>
 </devices>
 </deviceset>
-<deviceset name="100OHM" urn="urn:adsk.eagle:component:39762/1" prefix="R" library_version="1">
-<description>&lt;h3&gt;100Ω resistor&lt;/h3&gt;
-&lt;p&gt;A resistor is a passive two-terminal electrical component that implements electrical resistance as a circuit element. Resistors act to reduce current flow, and, at the same time, act to lower voltage levels within circuits. - Wikipedia&lt;/p&gt;</description>
+<deviceset name="R" urn="urn:adsk.eagle:component:2539478/17" prefix="R" uservalue="yes" library_version="103" library_locally_modified="yes">
 <gates>
-<gate name="G$1" symbol="RESISTOR" x="0" y="0"/>
+<gate name="G$1" symbol="R" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-HORIZ-1/4W-1%" package="AXIAL-0.3">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39658/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12181" constant="no"/>
-<attribute name="VALUE" value="100" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-HORIZ_KIT-1/4W-1%" package="AXIAL-0.3EZ">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39655/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12181" constant="no"/>
-<attribute name="VALUE" value="100" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT-1/4W-1%" package="AXIAL-0.1">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39656/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12181"/>
-<attribute name="VALUE" value="100"/>
-</technology>
-</technologies>
-</device>
-<device name="-VERT_KIT-1/4W-1%" package="AXIAL-0.1-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="P$1"/>
-<connect gate="G$1" pin="2" pad="P$2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39653/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12181" constant="no"/>
-<attribute name="VALUE" value="100" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-0603-1/4W-5%" package="0603">
+<device name="-0402" package="R0402">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39650/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539456/2"/>
 </package3dinstances>
 <technologies>
-<technology name="">
-<attribute name="PROD_ID" value="RES-12438"/>
-<attribute name="VALUE" value="100"/>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0402" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0402" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
 </technology>
 </technologies>
 </device>
-<device name="-0603-1/10W-1%" package="0603">
+<device name="-0805" package="R0805">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39650/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539455/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0805" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0805" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0603" package="R0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539454/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0603" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0603" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1206" package="R1206">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539464/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="1206" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="1206" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-2512" package="R2512">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4855216/2"/>
+</package3dinstances>
+<technologies>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="2512" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="2512" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-2010" package="R2010">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:26916226/1"/>
+</package3dinstances>
+<technologies>
+<technology name="-1%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="2010" constant="no"/>
+<attribute name="TOLERANCE" value="1%" constant="no"/>
+</technology>
+<technology name="-5%">
+<attribute name="AEC-Q" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="2010" constant="no"/>
+<attribute name="TOLERANCE" value="5%" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="LED" urn="urn:adsk.eagle:component:2539475/15" prefix="LED" library_version="103" library_locally_modified="yes">
+<description>Light  emitting diode</description>
+<gates>
+<gate name="G$1" symbol="LED" x="2.54" y="0"/>
+</gates>
+<devices>
+<device name="-0402" package="LED0402">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539470/3"/>
 </package3dinstances>
 <technologies>
 <technology name="">
-<attribute name="PROD_ID" value="RES-07863"/>
-<attribute name="VALUE" value="100"/>
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="OPERATING_TEMP" value="" constant="no"/>
+<attribute name="PACKAGE" value="0402" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0603" package="LED0603">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539471/4"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0603" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0805" package="LED0805">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539472/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="0805" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-1206" package="LED1206">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2539473/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="1206" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-TH-3MM" package="LED3MM">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="K"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:24459249/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="RADIAL 3MM" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-4014" package="LED4014">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:27229818/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="4014" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-3014" package="LED3014">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:27230109/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="COLOR" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+<attribute name="PACKAGE" value="3014" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="L" urn="urn:adsk.eagle:component:5347946/7" prefix="L" library_version="103" library_locally_modified="yes">
+<gates>
+<gate name="G$1" symbol="L" x="2.54" y="2.54"/>
+</gates>
+<devices>
+<device name="-0402" package="L0402">
+<connects>
+<connect gate="G$1" pin="P$1" pad="1"/>
+<connect gate="G$1" pin="P$2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5347945/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0603" package="L0603">
+<connects>
+<connect gate="G$1" pin="P$1" pad="1"/>
+<connect gate="G$1" pin="P$2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:8766559/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-0805" package="L0805">
+<connects>
+<connect gate="G$1" pin="P$1" pad="1"/>
+<connect gate="G$1" pin="P$2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:32710307/2"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="ALLOCATED" value="" constant="no"/>
+<attribute name="DIGIKEY#" value="" constant="no"/>
+<attribute name="LCSC#" value="" constant="no"/>
+<attribute name="MANF" value="" constant="no"/>
+<attribute name="MANF#" value="" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -2231,429 +2710,27 @@ Warning: This is the KIT version of the AXIAL-0.1 package. This package has a sm
 </deviceset>
 </devicesets>
 </library>
-<library name="SparkFun-Capacitors" urn="urn:adsk.eagle:library:510">
-<description>&lt;h3&gt;SparkFun Capacitors&lt;/h3&gt;
-This library contains capacitors. 
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
+<library name="supply_symbols" urn="urn:adsk.eagle:library:5017758">
 <packages>
-<package name="0603" urn="urn:adsk.eagle:footprint:37386/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 1608 (0603) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-1.6" y1="0.7" x2="1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="0.7" x2="1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="1.6" y1="-0.7" x2="-1.6" y2="-0.7" width="0.0508" layer="39"/>
-<wire x1="-1.6" y1="-0.7" x2="-1.6" y2="0.7" width="0.0508" layer="39"/>
-<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
-<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
-<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<text x="0" y="0.762" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.762" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
-<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-</package>
-<package name="1206" urn="urn:adsk.eagle:footprint:37399/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 3216 (1206) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-2.4" y1="1.1" x2="2.4" y2="1.1" width="0.0508" layer="39"/>
-<wire x1="2.4" y1="-1.1" x2="-2.4" y2="-1.1" width="0.0508" layer="39"/>
-<wire x1="-2.4" y1="-1.1" x2="-2.4" y2="1.1" width="0.0508" layer="39"/>
-<wire x1="2.4" y1="1.1" x2="2.4" y2="-1.1" width="0.0508" layer="39"/>
-<wire x1="-0.965" y1="0.787" x2="0.965" y2="0.787" width="0.1016" layer="51"/>
-<wire x1="-0.965" y1="-0.787" x2="0.965" y2="-0.787" width="0.1016" layer="51"/>
-<smd name="1" x="-1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
-<smd name="2" x="1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
-<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.143" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="-1.7018" y1="-0.8509" x2="-0.9517" y2="0.8491" layer="51"/>
-<rectangle x1="0.9517" y1="-0.8491" x2="1.7018" y2="0.8509" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
-</package>
-<package name="0805" urn="urn:adsk.eagle:footprint:37400/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 2012 (0805) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<smd name="1" x="-0.9" y="0" dx="0.8" dy="1.2" layer="1"/>
-<smd name="2" x="0.9" y="0" dx="0.8" dy="1.2" layer="1"/>
-<text x="0" y="0.889" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.889" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<wire x1="-1.5" y1="0.8" x2="1.5" y2="0.8" width="0.0508" layer="39"/>
-<wire x1="1.5" y1="0.8" x2="1.5" y2="-0.8" width="0.0508" layer="39"/>
-<wire x1="1.5" y1="-0.8" x2="-1.5" y2="-0.8" width="0.0508" layer="39"/>
-<wire x1="-1.5" y1="-0.8" x2="-1.5" y2="0.8" width="0.0508" layer="39"/>
-</package>
-<package name="1210" urn="urn:adsk.eagle:footprint:37401/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 3225 (1210) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-1.5365" y1="1.1865" x2="1.5365" y2="1.1865" width="0.127" layer="51"/>
-<wire x1="1.5365" y1="1.1865" x2="1.5365" y2="-1.1865" width="0.127" layer="51"/>
-<wire x1="1.5365" y1="-1.1865" x2="-1.5365" y2="-1.1865" width="0.127" layer="51"/>
-<wire x1="-1.5365" y1="-1.1865" x2="-1.5365" y2="1.1865" width="0.127" layer="51"/>
-<wire x1="-2.59" y1="1.45" x2="2.59" y2="1.45" width="0.0508" layer="39"/>
-<wire x1="2.59" y1="1.45" x2="2.59" y2="-1.45" width="0.0508" layer="39"/>
-<wire x1="2.59" y1="-1.45" x2="-2.59" y2="-1.45" width="0.0508" layer="39"/>
-<wire x1="-2.59" y1="-1.45" x2="-2.59" y2="1.45" width="0.0508" layer="39"/>
-<smd name="1" x="-1.755" y="0" dx="1.27" dy="2.06" layer="1"/>
-<smd name="2" x="1.755" y="0" dx="1.27" dy="2.06" layer="1"/>
-<text x="0" y="1.397" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.397" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-</package>
-<package name="0402" urn="urn:adsk.eagle:footprint:37389/1" library_version="1">
-<description>&lt;p&gt;&lt;b&gt;Generic 1005 (0402) package&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
-<wire x1="-0.2704" y1="0.2286" x2="0.2704" y2="0.2286" width="0.1524" layer="51"/>
-<wire x1="0.2704" y1="-0.2286" x2="-0.2704" y2="-0.2286" width="0.1524" layer="51"/>
-<wire x1="-1.2" y1="0.65" x2="1.2" y2="0.65" width="0.0508" layer="39"/>
-<wire x1="1.2" y1="0.65" x2="1.2" y2="-0.65" width="0.0508" layer="39"/>
-<wire x1="1.2" y1="-0.65" x2="-1.2" y2="-0.65" width="0.0508" layer="39"/>
-<wire x1="-1.2" y1="-0.65" x2="-1.2" y2="0.65" width="0.0508" layer="39"/>
-<smd name="1" x="-0.58" y="0" dx="0.85" dy="0.9" layer="1"/>
-<smd name="2" x="0.58" y="0" dx="0.85" dy="0.9" layer="1"/>
-<text x="0" y="0.762" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.762" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.3048" layer="51"/>
-<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.3048" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-</package>
-<package name="CAP-PTH-SMALL-KIT" urn="urn:adsk.eagle:footprint:37404/1" library_version="1">
-<description>&lt;h3&gt;CAP-PTH-SMALL-KIT&lt;/h3&gt;
-Commonly used for small ceramic capacitors. Like our 0.1uF (http://www.sparkfun.com/products/8375) or 22pF caps (http://www.sparkfun.com/products/8571).&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.</description>
-<wire x1="0" y1="0.635" x2="0" y2="-0.635" width="0.254" layer="21"/>
-<wire x1="-2.667" y1="1.27" x2="2.667" y2="1.27" width="0.254" layer="21"/>
-<wire x1="2.667" y1="1.27" x2="2.667" y2="-1.27" width="0.254" layer="21"/>
-<wire x1="2.667" y1="-1.27" x2="-2.667" y2="-1.27" width="0.254" layer="21"/>
-<wire x1="-2.667" y1="-1.27" x2="-2.667" y2="1.27" width="0.254" layer="21"/>
-<pad name="1" x="-1.397" y="0" drill="1.016" diameter="2.032" stop="no"/>
-<pad name="2" x="1.397" y="0" drill="1.016" diameter="2.032" stop="no"/>
-<polygon width="0.127" layer="30">
-<vertex x="-1.4021" y="-0.9475" curve="-90"/>
-<vertex x="-2.357" y="-0.0178" curve="-90.011749"/>
-<vertex x="-1.4046" y="0.9576" curve="-90"/>
-<vertex x="-0.4546" y="-0.0204" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-1.4046" y="-0.4395" curve="-90.012891"/>
-<vertex x="-1.8491" y="-0.0153" curve="-90"/>
-<vertex x="-1.4046" y="0.452" curve="-90"/>
-<vertex x="-0.9627" y="-0.0051" curve="-90.012967"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="1.397" y="-0.9475" curve="-90"/>
-<vertex x="0.4421" y="-0.0178" curve="-90.011749"/>
-<vertex x="1.3945" y="0.9576" curve="-90"/>
-<vertex x="2.3445" y="-0.0204" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="1.3945" y="-0.4395" curve="-90.012891"/>
-<vertex x="0.95" y="-0.0153" curve="-90"/>
-<vertex x="1.3945" y="0.452" curve="-90"/>
-<vertex x="1.8364" y="-0.0051" curve="-90.012967"/>
-</polygon>
-</package>
 </packages>
-<packages3d>
-<package3d name="0603" urn="urn:adsk.eagle:package:37414/1" type="box" library_version="1">
-<description>Generic 1608 (0603) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="0603"/>
-</packageinstances>
-</package3d>
-<package3d name="0805" urn="urn:adsk.eagle:package:37429/1" type="box" library_version="1">
-<description>Generic 2012 (0805) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="0805"/>
-</packageinstances>
-</package3d>
-<package3d name="0402" urn="urn:adsk.eagle:package:37413/1" type="box" library_version="1">
-<description>Generic 1005 (0402) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="0402"/>
-</packageinstances>
-</package3d>
-<package3d name="CAP-PTH-SMALL-KIT" urn="urn:adsk.eagle:package:37428/1" type="box" library_version="1">
-<description>CAP-PTH-SMALL-KIT
-Commonly used for small ceramic capacitors. Like our 0.1uF (http://www.sparkfun.com/products/8375) or 22pF caps (http://www.sparkfun.com/products/8571).
-
-Warning: This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.</description>
-<packageinstances>
-<packageinstance name="CAP-PTH-SMALL-KIT"/>
-</packageinstances>
-</package3d>
-<package3d name="1206" urn="urn:adsk.eagle:package:37426/1" type="box" library_version="1">
-<description>Generic 3216 (1206) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="1206"/>
-</packageinstances>
-</package3d>
-<package3d name="1210" urn="urn:adsk.eagle:package:37436/1" type="box" library_version="1">
-<description>Generic 3225 (1210) package
-0.2mm courtyard excess rounded to nearest 0.05mm.</description>
-<packageinstances>
-<packageinstance name="1210"/>
-</packageinstances>
-</package3d>
-</packages3d>
 <symbols>
-<symbol name="CAP" urn="urn:adsk.eagle:symbol:37385/1" library_version="1">
-<wire x1="0" y1="2.54" x2="0" y2="2.032" width="0.1524" layer="94"/>
-<wire x1="0" y1="0" x2="0" y2="0.508" width="0.1524" layer="94"/>
-<text x="1.524" y="2.921" size="1.778" layer="95" font="vector">&gt;NAME</text>
-<text x="1.524" y="-2.159" size="1.778" layer="96" font="vector">&gt;VALUE</text>
-<rectangle x1="-2.032" y1="0.508" x2="2.032" y2="1.016" layer="94"/>
-<rectangle x1="-2.032" y1="1.524" x2="2.032" y2="2.032" layer="94"/>
-<pin name="1" x="0" y="5.08" visible="off" length="short" direction="pas" swaplevel="1" rot="R270"/>
-<pin name="2" x="0" y="-2.54" visible="off" length="short" direction="pas" swaplevel="1" rot="R90"/>
+<symbol name="GND" urn="urn:adsk.eagle:symbol:5017787/1" library_version="5">
+<wire x1="-1.905" y1="0" x2="1.905" y2="0" width="0.254" layer="94"/>
+<text x="0" y="-1.27" size="1.27" layer="96" font="vector" ratio="15" align="center">&gt;VALUE</text>
+<pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="10UF" urn="urn:adsk.eagle:component:37478/1" prefix="C" library_version="1">
-<description>&lt;h3&gt;10.0µF ceramic capacitors&lt;/h3&gt;
-&lt;p&gt;A capacitor is a passive two-terminal electrical component used to store electrical energy temporarily in an electric field.&lt;/p&gt;</description>
+<deviceset name="GND" urn="urn:adsk.eagle:component:5017818/1" prefix="GND" library_version="5">
+<description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
 <gates>
-<gate name="G$1" symbol="CAP" x="0" y="0"/>
+<gate name="1" symbol="GND" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-0603-6.3V-20%" package="0603">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37414/1"/>
-</package3dinstances>
+<device name="">
 <technologies>
 <technology name="">
-<attribute name="PROD_ID" value="CAP-11015"/>
-<attribute name="VALUE" value="10uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-1206-6.3V-20%" package="1206">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37426/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-10057"/>
-<attribute name="VALUE" value="10uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-0805-10V-10%" package="0805">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37429/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-11330"/>
-<attribute name="VALUE" value="10uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-1210-50V-20%" package="1210">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37436/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-09824"/>
-<attribute name="VALUE" value="10uF"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="0.1UF" urn="urn:adsk.eagle:component:37472/1" prefix="C" library_version="1">
-<description>&lt;h3&gt;0.1µF ceramic capacitors&lt;/h3&gt;
-&lt;p&gt;A capacitor is a passive two-terminal electrical component used to store electrical energy temporarily in an electric field.&lt;/p&gt;</description>
-<gates>
-<gate name="G$1" symbol="CAP" x="0" y="0"/>
-</gates>
-<devices>
-<device name="-0402-16V-10%" package="0402">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37413/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-12416"/>
-<attribute name="VALUE" value="0.1uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-0603-25V-(+80/-20%)" package="0603">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37414/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-00810"/>
-<attribute name="VALUE" value="0.1uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-0603-25V-5%" package="0603">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37414/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-08604"/>
-<attribute name="VALUE" value="0.1uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-KIT-EZ-50V-20%" package="CAP-PTH-SMALL-KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37428/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-08370"/>
-<attribute name="VALUE" value="0.1uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-0603-100V-10%" package="0603">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37414/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-08390"/>
-<attribute name="VALUE" value="0.1uF"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="1.0UF" urn="urn:adsk.eagle:component:37474/1" prefix="C" library_version="1">
-<description>&lt;h3&gt;1µF ceramic capacitors&lt;/h3&gt;
-&lt;p&gt;A capacitor is a passive two-terminal electrical component used to store electrical energy temporarily in an electric field.&lt;/p&gt;</description>
-<gates>
-<gate name="G$1" symbol="CAP" x="0" y="0"/>
-</gates>
-<devices>
-<device name="-0603-16V-10%" package="0603">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37414/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-00868"/>
-<attribute name="VALUE" value="1.0uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-0402-16V-10%" package="0402">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37413/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-12417"/>
-<attribute name="VALUE" value="1.0uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-0805-25V-(+80/-20%)" package="0805">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37429/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-11625"/>
-<attribute name="VALUE" value="1.0uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-1206-50V-10%" package="1206">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37426/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-09822"/>
-<attribute name="VALUE" value="1.0uF"/>
-</technology>
-</technologies>
-</device>
-<device name="-0805-25V-10%" package="0805">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:37429/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CAP-08064"/>
-<attribute name="VALUE" value="1.0uF"/>
+<attribute name="VALUE" value="GND" constant="no"/>
 </technology>
 </technologies>
 </device>
@@ -2661,66 +2738,44 @@ Warning: This is the KIT version of this package. This package has a smaller dia
 </deviceset>
 </devicesets>
 </library>
-<library name="SOP50P310X90-8N">
+<library name="frames" urn="urn:adsk.eagle:library:229">
+<description>&lt;b&gt;Frames for Sheet and Layout&lt;/b&gt;</description>
 <packages>
-<package name="SOP50P310X90-8N">
-<text x="-3.09725" y="-1.638140625" size="1.6955" layer="27" align="top-left">&gt;VALUE</text>
-<text x="-3.179609375" y="1.681640625" size="1.74053125" layer="25">&gt;NAME</text>
-<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="21"/>
-<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="51"/>
-<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="51"/>
-<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="51"/>
-<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="21"/>
-<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="21"/>
-<wire x1="-1.15" y1="1" x2="-1.15" y2="-1" width="0.127" layer="51"/>
-<wire x1="1.15" y1="1" x2="1.15" y2="-1" width="0.127" layer="51"/>
-<wire x1="-2.215" y1="1.25" x2="2.215" y2="1.25" width="0.05" layer="39"/>
-<wire x1="-2.215" y1="-1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
-<wire x1="-2.215" y1="1.25" x2="-2.215" y2="-1.25" width="0.05" layer="39"/>
-<wire x1="2.215" y1="1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
-<smd name="1" x="-1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="2" x="-1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="3" x="-1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="4" x="-1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="5" x="1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="6" x="1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="7" x="1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-<smd name="8" x="1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
-</package>
 </packages>
 <symbols>
-<symbol name="SN74LVC2T45DCUR">
-<pin name="VCCA" x="-15.24" y="7.62" length="middle"/>
-<pin name="A1" x="-15.24" y="2.54" length="middle"/>
-<pin name="A2" x="-15.24" y="-2.54" length="middle"/>
-<pin name="GND" x="-15.24" y="-7.62" length="middle"/>
-<pin name="VCCB" x="15.24" y="7.62" length="middle" rot="R180"/>
-<pin name="B1" x="15.24" y="2.54" length="middle" rot="R180"/>
-<pin name="B2" x="15.24" y="-2.54" length="middle" rot="R180"/>
-<pin name="DIR" x="15.24" y="-7.62" length="middle" rot="R180"/>
-<wire x1="-10.16" y1="10.16" x2="-10.16" y2="-10.16" width="0.254" layer="94"/>
-<wire x1="-10.16" y1="-10.16" x2="10.16" y2="-10.16" width="0.254" layer="94"/>
-<wire x1="10.16" y1="-10.16" x2="10.16" y2="10.16" width="0.254" layer="94"/>
-<wire x1="10.16" y1="10.16" x2="-10.16" y2="10.16" width="0.254" layer="94"/>
+<symbol name="A4L-LOC" urn="urn:adsk.eagle:symbol:13874/1" library_version="1">
+<wire x1="256.54" y1="3.81" x2="256.54" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="256.54" y1="8.89" x2="256.54" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="256.54" y1="13.97" x2="256.54" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="256.54" y1="19.05" x2="256.54" y2="24.13" width="0.1016" layer="94"/>
+<wire x1="161.29" y1="3.81" x2="161.29" y2="24.13" width="0.1016" layer="94"/>
+<wire x1="161.29" y1="24.13" x2="215.265" y2="24.13" width="0.1016" layer="94"/>
+<wire x1="215.265" y1="24.13" x2="256.54" y2="24.13" width="0.1016" layer="94"/>
+<wire x1="246.38" y1="3.81" x2="246.38" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="246.38" y1="8.89" x2="256.54" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="246.38" y1="8.89" x2="215.265" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="215.265" y1="8.89" x2="215.265" y2="3.81" width="0.1016" layer="94"/>
+<wire x1="215.265" y1="8.89" x2="215.265" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="215.265" y1="13.97" x2="256.54" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="215.265" y1="13.97" x2="215.265" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="215.265" y1="19.05" x2="256.54" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="215.265" y1="19.05" x2="215.265" y2="24.13" width="0.1016" layer="94"/>
+<text x="217.17" y="15.24" size="2.54" layer="94">&gt;DRAWING_NAME</text>
+<text x="217.17" y="10.16" size="2.286" layer="94">&gt;LAST_DATE_TIME</text>
+<text x="230.505" y="5.08" size="2.54" layer="94">&gt;SHEET</text>
+<text x="216.916" y="4.953" size="2.54" layer="94">Sheet:</text>
+<frame x1="0" y1="0" x2="260.35" y2="179.07" columns="6" rows="4" layer="94"/>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="SN74LVC2T45DCUR">
+<deviceset name="A4L-LOC" urn="urn:adsk.eagle:component:13926/1" prefix="FRAME" uservalue="yes" library_version="1">
+<description>&lt;b&gt;FRAME&lt;/b&gt;&lt;p&gt;
+DIN A4, landscape with location and doc. field</description>
 <gates>
-<gate name="G$1" symbol="SN74LVC2T45DCUR" x="-10.16" y="-2.54"/>
+<gate name="G$1" symbol="A4L-LOC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP50P310X90-8N">
-<connects>
-<connect gate="G$1" pin="A1" pad="2"/>
-<connect gate="G$1" pin="A2" pad="3"/>
-<connect gate="G$1" pin="B1" pad="7"/>
-<connect gate="G$1" pin="B2" pad="6"/>
-<connect gate="G$1" pin="DIR" pad="5"/>
-<connect gate="G$1" pin="GND" pad="4"/>
-<connect gate="G$1" pin="VCCA" pad="1"/>
-<connect gate="G$1" pin="VCCB" pad="8"/>
-</connects>
+<device name="">
 <technologies>
 <technology name=""/>
 </technologies>
@@ -2729,754 +2784,9 @@ Warning: This is the KIT version of this package. This package has a smaller dia
 </deviceset>
 </devicesets>
 </library>
-<library name="SparkFun-Switches" urn="urn:adsk.eagle:library:535">
-<description>&lt;h3&gt;SparkFun Switches, Buttons, Encoders&lt;/h3&gt;
-In this library you'll find switches, buttons, joysticks, and anything that moves to create or disrupt an electrical connection.
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
+<library name="pixelblaze" urn="urn:adsk.eagle:library:35450543">
 <packages>
-<package name="TACTILE_SWITCH_PTH_6.0MM" urn="urn:adsk.eagle:footprint:40103/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-1000)&lt;/p&gt;</description>
-<wire x1="3.048" y1="1.016" x2="3.048" y2="2.54" width="0.2032" layer="51"/>
-<wire x1="3.048" y1="2.54" x2="2.54" y2="3.048" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="-3.048" x2="3.048" y2="-2.54" width="0.2032" layer="51"/>
-<wire x1="3.048" y1="-2.54" x2="3.048" y2="-1.016" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="3.048" x2="-3.048" y2="2.54" width="0.2032" layer="51"/>
-<wire x1="-3.048" y1="2.54" x2="-3.048" y2="1.016" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-3.048" x2="-3.048" y2="-2.54" width="0.2032" layer="51"/>
-<wire x1="-3.048" y1="-2.54" x2="-3.048" y2="-1.016" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-3.048" x2="-2.159" y2="-3.048" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="3.048" x2="2.159" y2="3.048" width="0.2032" layer="51"/>
-<wire x1="2.159" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="21"/>
-<wire x1="-2.159" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="21"/>
-<wire x1="3.048" y1="0.998" x2="3.048" y2="-1.016" width="0.2032" layer="21"/>
-<wire x1="-3.048" y1="1.028" x2="-3.048" y2="-1.016" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="1.27" x2="-2.54" y2="0.508" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-0.508" x2="-2.54" y2="-1.27" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="0.508" x2="-2.159" y2="-0.381" width="0.2032" layer="51"/>
-<circle x="0" y="0" radius="1.778" width="0.2032" layer="21"/>
-<pad name="1" x="-3.2512" y="2.2606" drill="1.016" diameter="1.8796"/>
-<pad name="2" x="3.2512" y="2.2606" drill="1.016" diameter="1.8796"/>
-<pad name="3" x="-3.2512" y="-2.2606" drill="1.016" diameter="1.8796"/>
-<pad name="4" x="3.2512" y="-2.2606" drill="1.016" diameter="1.8796"/>
-<text x="0" y="3.302" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-3.175" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_SMD_4.5MM" urn="urn:adsk.eagle:footprint:40104/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 4.5mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="http://spec_sheets.e-switch.com/specs/P010338.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
-<wire x1="1.905" y1="1.27" x2="1.905" y2="0.445" width="0.127" layer="51"/>
-<wire x1="1.905" y1="0.445" x2="2.16" y2="-0.01" width="0.127" layer="51"/>
-<wire x1="1.905" y1="-0.23" x2="1.905" y2="-1.115" width="0.127" layer="51"/>
-<wire x1="-2.25" y1="2.25" x2="2.25" y2="2.25" width="0.127" layer="51"/>
-<wire x1="2.25" y1="2.25" x2="2.25" y2="-2.25" width="0.127" layer="51"/>
-<wire x1="2.25" y1="-2.25" x2="-2.25" y2="-2.25" width="0.127" layer="51"/>
-<wire x1="-2.25" y1="-2.25" x2="-2.25" y2="2.25" width="0.127" layer="51"/>
-<wire x1="-2.2" y1="0.8" x2="-2.2" y2="-0.8" width="0.2032" layer="21"/>
-<wire x1="1.3" y1="2.2" x2="-1.3" y2="2.2" width="0.2032" layer="21"/>
-<wire x1="2.2" y1="-0.8" x2="2.2" y2="0.8" width="0.2032" layer="21"/>
-<wire x1="-1.3" y1="-2.2" x2="1.3" y2="-2.2" width="0.2032" layer="21"/>
-<wire x1="2.2" y1="0.8" x2="1.8" y2="0.8" width="0.2032" layer="21"/>
-<wire x1="2.2" y1="-0.8" x2="1.8" y2="-0.8" width="0.2032" layer="21"/>
-<wire x1="-1.8" y1="0.8" x2="-2.2" y2="0.8" width="0.2032" layer="21"/>
-<wire x1="-1.8" y1="-0.8" x2="-2.2" y2="-0.8" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="1.27" width="0.2032" layer="21"/>
-<smd name="1" x="2.225" y="1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
-<smd name="2" x="2.225" y="-1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
-<smd name="3" x="-2.225" y="-1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
-<smd name="4" x="-2.225" y="1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
-<text x="0" y="2.413" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-2.413" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_PTH_12MM" urn="urn:adsk.eagle:footprint:40105/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 12mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-5050)&lt;/p&gt;</description>
-<wire x1="5" y1="-1.3" x2="5" y2="-0.7" width="0.2032" layer="51"/>
-<wire x1="5" y1="-0.7" x2="4.5" y2="-0.2" width="0.2032" layer="51"/>
-<wire x1="5" y1="0.2" x2="5" y2="1" width="0.2032" layer="51"/>
-<wire x1="-6" y1="4" x2="-6" y2="5" width="0.2032" layer="21"/>
-<wire x1="-5" y1="6" x2="5" y2="6" width="0.2032" layer="21"/>
-<wire x1="6" y1="5" x2="6" y2="4" width="0.2032" layer="21"/>
-<wire x1="6" y1="1" x2="6" y2="-1" width="0.2032" layer="21"/>
-<wire x1="6" y1="-4" x2="6" y2="-5" width="0.2032" layer="21"/>
-<wire x1="5" y1="-6" x2="-5" y2="-6" width="0.2032" layer="21"/>
-<wire x1="-6" y1="-5" x2="-6" y2="-4" width="0.2032" layer="21"/>
-<wire x1="-6" y1="-1" x2="-6" y2="1" width="0.2032" layer="21"/>
-<wire x1="-6" y1="5" x2="-5" y2="6" width="0.2032" layer="21" curve="-90"/>
-<wire x1="5" y1="6" x2="6" y2="5" width="0.2032" layer="21" curve="-90"/>
-<wire x1="6" y1="-5" x2="5" y2="-6" width="0.2032" layer="21" curve="-90"/>
-<wire x1="-5" y1="-6" x2="-6" y2="-5" width="0.2032" layer="21" curve="-90"/>
-<circle x="0" y="0" radius="3.5" width="0.2032" layer="21"/>
-<circle x="-4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
-<circle x="4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
-<circle x="4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
-<circle x="-4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
-<pad name="4" x="-6.25" y="2.5" drill="1.2" diameter="2.159"/>
-<pad name="2" x="-6.25" y="-2.5" drill="1.2" diameter="2.159"/>
-<pad name="1" x="6.25" y="-2.5" drill="1.2" diameter="2.159"/>
-<pad name="3" x="6.25" y="2.5" drill="1.2" diameter="2.159"/>
-<text x="0" y="6.223" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-6.223" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_SMD_6.0X3.5MM" urn="urn:adsk.eagle:footprint:40106/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 6.0 x 3.5 mm&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/1101.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
-<wire x1="-3" y1="1.1" x2="-3" y2="-1.1" width="0.127" layer="51"/>
-<wire x1="3" y1="1.1" x2="3" y2="-1.1" width="0.127" layer="51"/>
-<wire x1="-2.75" y1="1.75" x2="-3" y2="1.5" width="0.2032" layer="21" curve="90"/>
-<wire x1="-2.75" y1="1.75" x2="2.75" y2="1.75" width="0.2032" layer="21"/>
-<wire x1="2.75" y1="1.75" x2="3" y2="1.5" width="0.2032" layer="21" curve="-90"/>
-<wire x1="3" y1="-1.5" x2="2.75" y2="-1.75" width="0.2032" layer="21" curve="-90"/>
-<wire x1="2.75" y1="-1.75" x2="-2.75" y2="-1.75" width="0.2032" layer="21"/>
-<wire x1="-3" y1="-1.5" x2="-2.75" y2="-1.75" width="0.2032" layer="21" curve="90"/>
-<wire x1="-3" y1="-1.5" x2="-3" y2="-1.1" width="0.2032" layer="21"/>
-<wire x1="-3" y1="1.1" x2="-3" y2="1.5" width="0.2032" layer="21"/>
-<wire x1="3" y1="1.1" x2="3" y2="1.5" width="0.2032" layer="21"/>
-<wire x1="3" y1="-1.5" x2="3" y2="-1.1" width="0.2032" layer="21"/>
-<wire x1="-1.5" y1="0.75" x2="1.5" y2="0.75" width="0.2032" layer="21"/>
-<wire x1="1.5" y1="-0.75" x2="-1.5" y2="-0.75" width="0.2032" layer="21"/>
-<wire x1="-1.5" y1="-0.75" x2="-1.5" y2="0.75" width="0.2032" layer="21"/>
-<wire x1="1.5" y1="-0.75" x2="1.5" y2="0.75" width="0.2032" layer="21"/>
-<wire x1="-2" y1="0" x2="-1" y2="0" width="0.127" layer="51"/>
-<wire x1="-1" y1="0" x2="0.1" y2="0.5" width="0.127" layer="51"/>
-<wire x1="0.3" y1="0" x2="2" y2="0" width="0.127" layer="51"/>
-<smd name="1" x="-3.15" y="0" dx="2.3" dy="1.6" layer="1" rot="R180"/>
-<smd name="2" x="3.15" y="0" dx="2.3" dy="1.6" layer="1" rot="R180"/>
-<text x="0" y="1.905" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-1.905" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_SMD_6.2MM_TALL" urn="urn:adsk.eagle:footprint:40107/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 6.2mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="http://www.apem.com/files/apem/brochures/ADTS6-ADTSM-KTSC6.pdf"&gt;Datasheet&lt;/a&gt; (ADTSM63NVTR)&lt;/p&gt;</description>
-<wire x1="-3" y1="-3" x2="3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3" y1="-3" x2="3" y2="3" width="0.2032" layer="21"/>
-<wire x1="3" y1="3" x2="-3" y2="3" width="0.2032" layer="21"/>
-<wire x1="-3" y1="3" x2="-3" y2="-3" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="1.75" width="0.2032" layer="21"/>
-<smd name="A1" x="-3.975" y="-2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
-<smd name="A2" x="3.975" y="-2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
-<smd name="B1" x="-3.975" y="2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
-<smd name="B2" x="3.975" y="2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
-<text x="0" y="3.175" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-3.175" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT" urn="urn:adsk.eagle:footprint:40108/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, Right-angle&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="http://cdn.sparkfun.com/datasheets/Components/Switches/SW016.JPG"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
-<wire x1="1.5" y1="-3.8" x2="-1.5" y2="-3.8" width="0.127" layer="51"/>
-<wire x1="-3.65" y1="-2" x2="-3.65" y2="3.5" width="0.127" layer="51"/>
-<wire x1="-3.65" y1="3.5" x2="-3" y2="3.5" width="0.127" layer="51"/>
-<wire x1="3" y1="3.5" x2="3.65" y2="3.5" width="0.127" layer="51"/>
-<wire x1="3.65" y1="3.5" x2="3.65" y2="-2" width="0.127" layer="51"/>
-<wire x1="-3" y1="2" x2="3" y2="2" width="0.127" layer="51"/>
-<wire x1="-3" y1="2" x2="-3" y2="3.5" width="0.127" layer="51"/>
-<wire x1="3" y1="2" x2="3" y2="3.5" width="0.127" layer="51"/>
-<wire x1="-3.65" y1="-2" x2="-1.5" y2="-2" width="0.127" layer="51"/>
-<wire x1="-1.5" y1="-2" x2="1.5" y2="-2" width="0.127" layer="51"/>
-<wire x1="1.5" y1="-2" x2="3.65" y2="-2" width="0.127" layer="51"/>
-<wire x1="1.5" y1="-2" x2="1.5" y2="-3.8" width="0.127" layer="51"/>
-<wire x1="-1.5" y1="-2" x2="-1.5" y2="-3.8" width="0.127" layer="51"/>
-<wire x1="-3.777" y1="1" x2="-3.777" y2="-2.127" width="0.2032" layer="21"/>
-<wire x1="-3.777" y1="-2.127" x2="3.777" y2="-2.127" width="0.2032" layer="21"/>
-<wire x1="3.777" y1="-2.127" x2="3.777" y2="1" width="0.2032" layer="21"/>
-<wire x1="2" y1="2.127" x2="-2" y2="2.127" width="0.2032" layer="21"/>
-<pad name="ANCHOR1" x="-3.5" y="2.5" drill="1.2" diameter="2.2" stop="no"/>
-<pad name="ANCHOR2" x="3.5" y="2.5" drill="1.2" diameter="2.2" stop="no"/>
-<pad name="1" x="-2.5" y="0" drill="0.8" diameter="1.7" stop="no"/>
-<pad name="2" x="2.5" y="0" drill="0.8" diameter="1.7" stop="no"/>
-<circle x="2.5" y="0" radius="0.4445" width="0" layer="29"/>
-<circle x="-2.5" y="0" radius="0.4445" width="0" layer="29"/>
-<circle x="-3.5" y="2.5" radius="0.635" width="0" layer="29"/>
-<circle x="3.5" y="2.5" radius="0.635" width="0" layer="29"/>
-<circle x="-3.5" y="2.5" radius="1.143" width="0" layer="30"/>
-<circle x="2.5" y="0" radius="0.889" width="0" layer="30"/>
-<circle x="-2.5" y="0" radius="0.889" width="0" layer="30"/>
-<circle x="3.5" y="2.5" radius="1.143" width="0" layer="30"/>
-<text x="0" y="2.286" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_SMD_12MM" urn="urn:adsk.eagle:footprint:40109/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 12mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="https://cdn.sparkfun.com/datasheets/Components/Switches/N301102.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
-<wire x1="5" y1="-1.3" x2="5" y2="-0.7" width="0.2032" layer="51"/>
-<wire x1="5" y1="-0.7" x2="4.5" y2="-0.2" width="0.2032" layer="51"/>
-<wire x1="5" y1="0.2" x2="5" y2="1" width="0.2032" layer="51"/>
-<wire x1="-6" y1="4" x2="-6" y2="5" width="0.2032" layer="21"/>
-<wire x1="-5" y1="6" x2="5" y2="6" width="0.2032" layer="21"/>
-<wire x1="6" y1="5" x2="6" y2="4" width="0.2032" layer="21"/>
-<wire x1="6" y1="1" x2="6" y2="-1" width="0.2032" layer="21"/>
-<wire x1="6" y1="-4" x2="6" y2="-5" width="0.2032" layer="21"/>
-<wire x1="5" y1="-6" x2="-5" y2="-6" width="0.2032" layer="21"/>
-<wire x1="-6" y1="-5" x2="-6" y2="-4" width="0.2032" layer="21"/>
-<wire x1="-6" y1="-1" x2="-6" y2="1" width="0.2032" layer="21"/>
-<wire x1="-6" y1="-5" x2="-5" y2="-6" width="0.2032" layer="21"/>
-<wire x1="6" y1="-5" x2="5" y2="-6" width="0.2032" layer="21"/>
-<wire x1="6" y1="5" x2="5" y2="6" width="0.2032" layer="21"/>
-<wire x1="-5" y1="6" x2="-6" y2="5" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="3.5" width="0.2032" layer="21"/>
-<circle x="-4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
-<circle x="4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
-<circle x="4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
-<circle x="-4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
-<smd name="4" x="-6.975" y="2.5" dx="1.6" dy="1.55" layer="1"/>
-<smd name="2" x="-6.975" y="-2.5" dx="1.6" dy="1.55" layer="1"/>
-<smd name="1" x="6.975" y="-2.5" dx="1.6" dy="1.55" layer="1"/>
-<smd name="3" x="6.975" y="2.5" dx="1.6" dy="1.55" layer="1"/>
-<text x="0" y="6.223" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-6.223" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_PTH_6.0MM_KIT" urn="urn:adsk.eagle:footprint:40110/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;
-&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-1000)&lt;/p&gt;</description>
-<wire x1="3.048" y1="1.016" x2="3.048" y2="2.54" width="0.2032" layer="51"/>
-<wire x1="3.048" y1="2.54" x2="2.54" y2="3.048" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="-3.048" x2="3.048" y2="-2.54" width="0.2032" layer="51"/>
-<wire x1="3.048" y1="-2.54" x2="3.048" y2="-1.016" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="3.048" x2="-3.048" y2="2.54" width="0.2032" layer="51"/>
-<wire x1="-3.048" y1="2.54" x2="-3.048" y2="1.016" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-3.048" x2="-3.048" y2="-2.54" width="0.2032" layer="51"/>
-<wire x1="-3.048" y1="-2.54" x2="-3.048" y2="-1.016" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-3.048" x2="-2.159" y2="-3.048" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="3.048" x2="2.159" y2="3.048" width="0.2032" layer="51"/>
-<wire x1="2.159" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="21"/>
-<wire x1="-2.159" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="21"/>
-<wire x1="3.048" y1="0.998" x2="3.048" y2="-1.016" width="0.2032" layer="21"/>
-<wire x1="-3.048" y1="1.028" x2="-3.048" y2="-1.016" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="1.27" x2="-2.54" y2="0.508" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-0.508" x2="-2.54" y2="-1.27" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="0.508" x2="-2.159" y2="-0.381" width="0.2032" layer="51"/>
-<circle x="0" y="0" radius="1.778" width="0.2032" layer="21"/>
-<pad name="1" x="-3.2512" y="2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<pad name="2" x="3.2512" y="2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<pad name="3" x="-3.2512" y="-2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<pad name="4" x="3.2512" y="-2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<polygon width="0.127" layer="30">
-<vertex x="-3.2664" y="3.142"/>
-<vertex x="-3.2589" y="3.1445" curve="89.986886"/>
-<vertex x="-4.1326" y="2.286"/>
-<vertex x="-4.1351" y="2.2657" curve="90.00652"/>
-<vertex x="-3.2563" y="1.392"/>
-<vertex x="-3.2487" y="1.3869" curve="90.006616"/>
-<vertex x="-2.3826" y="2.2403"/>
-<vertex x="-2.3775" y="2.2683" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-3.2462" y="2.7026"/>
-<vertex x="-3.2589" y="2.7051" curve="90.026544"/>
-<vertex x="-3.6881" y="2.2733"/>
-<vertex x="-3.6881" y="2.2632" curve="89.974074"/>
-<vertex x="-3.2562" y="1.8213"/>
-<vertex x="-3.2259" y="1.8186" curve="90.051271"/>
-<vertex x="-2.8093" y="2.2658"/>
-<vertex x="-2.8093" y="2.2606" curve="90.012964"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="3.2411" y="3.1395"/>
-<vertex x="3.2486" y="3.142" curve="89.986886"/>
-<vertex x="2.3749" y="2.2835"/>
-<vertex x="2.3724" y="2.2632" curve="90.00652"/>
-<vertex x="3.2512" y="1.3895"/>
-<vertex x="3.2588" y="1.3844" curve="90.006616"/>
-<vertex x="4.1249" y="2.2378"/>
-<vertex x="4.13" y="2.2658" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="3.2613" y="2.7001"/>
-<vertex x="3.2486" y="2.7026" curve="90.026544"/>
-<vertex x="2.8194" y="2.2708"/>
-<vertex x="2.8194" y="2.2607" curve="89.974074"/>
-<vertex x="3.2513" y="1.8188"/>
-<vertex x="3.2816" y="1.8161" curve="90.051271"/>
-<vertex x="3.6982" y="2.2633"/>
-<vertex x="3.6982" y="2.2581" curve="90.012964"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="-3.2613" y="-1.3868"/>
-<vertex x="-3.2538" y="-1.3843" curve="89.986886"/>
-<vertex x="-4.1275" y="-2.2428"/>
-<vertex x="-4.13" y="-2.2631" curve="90.00652"/>
-<vertex x="-3.2512" y="-3.1368"/>
-<vertex x="-3.2436" y="-3.1419" curve="90.006616"/>
-<vertex x="-2.3775" y="-2.2885"/>
-<vertex x="-2.3724" y="-2.2605" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-3.2411" y="-1.8262"/>
-<vertex x="-3.2538" y="-1.8237" curve="90.026544"/>
-<vertex x="-3.683" y="-2.2555"/>
-<vertex x="-3.683" y="-2.2656" curve="89.974074"/>
-<vertex x="-3.2511" y="-2.7075"/>
-<vertex x="-3.2208" y="-2.7102" curve="90.051271"/>
-<vertex x="-2.8042" y="-2.263"/>
-<vertex x="-2.8042" y="-2.2682" curve="90.012964"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="3.2411" y="-1.3843"/>
-<vertex x="3.2486" y="-1.3818" curve="89.986886"/>
-<vertex x="2.3749" y="-2.2403"/>
-<vertex x="2.3724" y="-2.2606" curve="90.00652"/>
-<vertex x="3.2512" y="-3.1343"/>
-<vertex x="3.2588" y="-3.1394" curve="90.006616"/>
-<vertex x="4.1249" y="-2.286"/>
-<vertex x="4.13" y="-2.258" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="3.2613" y="-1.8237"/>
-<vertex x="3.2486" y="-1.8212" curve="90.026544"/>
-<vertex x="2.8194" y="-2.253"/>
-<vertex x="2.8194" y="-2.2631" curve="89.974074"/>
-<vertex x="3.2513" y="-2.705"/>
-<vertex x="3.2816" y="-2.7077" curve="90.051271"/>
-<vertex x="3.6982" y="-2.2605"/>
-<vertex x="3.6982" y="-2.2657" curve="90.012964"/>
-</polygon>
-<text x="0" y="3.175" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-3.175" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:footprint:40111/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/Buttons/SMD-Button.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
-<wire x1="-1.54" y1="-2.54" x2="-2.54" y2="-1.54" width="0.2032" layer="51"/>
-<wire x1="-2.54" y1="-1.24" x2="-2.54" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="-2.54" y1="1.54" x2="-1.54" y2="2.54" width="0.2032" layer="51"/>
-<wire x1="-1.54" y1="2.54" x2="1.54" y2="2.54" width="0.2032" layer="21"/>
-<wire x1="1.54" y1="2.54" x2="2.54" y2="1.54" width="0.2032" layer="51"/>
-<wire x1="2.54" y1="1.24" x2="2.54" y2="-1.24" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-1.54" x2="1.54" y2="-2.54" width="0.2032" layer="51"/>
-<wire x1="1.54" y1="-2.54" x2="-1.54" y2="-2.54" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="1.905" y2="0.445" width="0.127" layer="51"/>
-<wire x1="1.905" y1="0.445" x2="2.16" y2="-0.01" width="0.127" layer="51"/>
-<wire x1="1.905" y1="-0.23" x2="1.905" y2="-1.115" width="0.127" layer="51"/>
-<circle x="0" y="0" radius="1.27" width="0.2032" layer="21"/>
-<smd name="1" x="-2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<smd name="2" x="2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<smd name="3" x="-2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<smd name="4" x="2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
-<text x="0" y="2.667" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-2.667" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_SMD_RIGHT_ANGLE" urn="urn:adsk.eagle:footprint:40112/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, Right-angle&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;</description>
-<hole x="0" y="0.9" drill="0.7"/>
-<hole x="0" y="-0.9" drill="0.7"/>
-<smd name="1" x="-1.95" y="0" dx="2" dy="1.1" layer="1" rot="R90"/>
-<smd name="2" x="1.95" y="0" dx="2" dy="1.1" layer="1" rot="R90"/>
-<wire x1="-2" y1="1.2" x2="-2" y2="1.5" width="0.2032" layer="21"/>
-<wire x1="-2" y1="1.5" x2="2" y2="1.5" width="0.2032" layer="21"/>
-<wire x1="2" y1="1.5" x2="2" y2="1.2" width="0.2032" layer="21"/>
-<wire x1="-2" y1="-1.2" x2="-2" y2="-1.5" width="0.2032" layer="21"/>
-<wire x1="-2" y1="-1.5" x2="-0.7" y2="-1.5" width="0.2032" layer="21"/>
-<wire x1="-0.7" y1="-1.5" x2="0.7" y2="-1.5" width="0.2032" layer="21"/>
-<wire x1="0.7" y1="-1.5" x2="2" y2="-1.5" width="0.2032" layer="21"/>
-<wire x1="2" y1="-1.5" x2="2" y2="-1.2" width="0.2032" layer="21"/>
-<wire x1="-0.7" y1="-2.1" x2="0.7" y2="-2.1" width="0.2032" layer="21"/>
-<wire x1="0.7" y1="-2.1" x2="0.7" y2="-1.5" width="0.2032" layer="21"/>
-<wire x1="-0.7" y1="-2.1" x2="-0.7" y2="-1.5" width="0.2032" layer="21"/>
-<text x="0" y="1.651" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-<package name="TACTILE_SWITCH_SMD_4.6X2.8MM" urn="urn:adsk.eagle:footprint:40113/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 4.6 x 2.8mm&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;a href="http://www.ck-components.com/media/1479/kmr2.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
-<smd name="3" x="2.05" y="0.8" dx="0.9" dy="1" layer="1"/>
-<smd name="2" x="2.05" y="-0.8" dx="0.9" dy="1" layer="1"/>
-<smd name="1" x="-2.05" y="-0.8" dx="0.9" dy="1" layer="1"/>
-<smd name="4" x="-2.05" y="0.8" dx="0.9" dy="1" layer="1"/>
-<wire x1="-2.1" y1="1.4" x2="-2.1" y2="-1.4" width="0.127" layer="51"/>
-<wire x1="2.1" y1="-1.4" x2="2.1" y2="1.4" width="0.127" layer="51"/>
-<wire x1="-2.1" y1="1.4" x2="2.1" y2="1.4" width="0.127" layer="51"/>
-<wire x1="-2.1" y1="-1.4" x2="2.1" y2="-1.4" width="0.127" layer="51"/>
-<wire x1="1.338" y1="-1.4" x2="-1.338" y2="-1.4" width="0.2032" layer="21"/>
-<wire x1="-1.338" y1="1.4" x2="1.338" y2="1.4" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="0.13" x2="-2.1" y2="-0.13" width="0.2032" layer="21"/>
-<wire x1="2.1" y1="-0.13" x2="2.1" y2="0.13" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="0.805" width="0.127" layer="21"/>
-<rectangle x1="-2.3" y1="0.5" x2="-2.1" y2="1.1" layer="51"/>
-<rectangle x1="-2.3" y1="-1.1" x2="-2.1" y2="-0.5" layer="51"/>
-<rectangle x1="2.1" y1="-1.1" x2="2.3" y2="-0.5" layer="51" rot="R180"/>
-<rectangle x1="2.1" y1="0.5" x2="2.3" y2="1.1" layer="51" rot="R180"/>
-<text x="0" y="1.524" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
-<text x="0" y="-1.524" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
-</package>
-</packages>
-<packages3d>
-<package3d name="TACTILE_SWITCH_PTH_6.0MM" urn="urn:adsk.eagle:package:40163/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Datasheet (B3F-1000)</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_PTH_6.0MM"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_SMD_4.5MM" urn="urn:adsk.eagle:package:40162/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, 4.5mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Dimensional Drawing</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_4.5MM"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_PTH_12MM" urn="urn:adsk.eagle:package:40164/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - PTH, 12mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Datasheet (B3F-5050)</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_PTH_12MM"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_SMD_6.0X3.5MM" urn="urn:adsk.eagle:package:40165/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, 6.0 x 3.5 mm
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Datasheet</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_6.0X3.5MM"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_SMD_6.2MM_TALL" urn="urn:adsk.eagle:package:40172/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, 6.2mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Datasheet (ADTSM63NVTR)</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_6.2MM_TALL"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT" urn="urn:adsk.eagle:package:40168/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - PTH, Right-angle
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Dimensional Drawing</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_SMD_12MM" urn="urn:adsk.eagle:package:40166/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, 12mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Datasheet</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_12MM"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_PTH_6.0MM_KIT" urn="urn:adsk.eagle:package:40170/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Warning: This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.
-Datasheet (B3F-1000)</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_PTH_6.0MM_KIT"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:package:40167/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Dimensional Drawing</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_5.2MM"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_SMD_RIGHT_ANGLE" urn="urn:adsk.eagle:package:40169/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, Right-angle
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_RIGHT_ANGLE"/>
-</packageinstances>
-</package3d>
-<package3d name="TACTILE_SWITCH_SMD_4.6X2.8MM" urn="urn:adsk.eagle:package:40176/1" type="box" library_version="1">
-<description>Momentary Switch (Pushbutton) - SPST - SMD, 4.6 x 2.8mm
-Normally-open (NO) SPST momentary switches (buttons, pushbuttons).
-Datasheet</description>
-<packageinstances>
-<packageinstance name="TACTILE_SWITCH_SMD_4.6X2.8MM"/>
-</packageinstances>
-</package3d>
-</packages3d>
-<symbols>
-<symbol name="SWITCH-MOMENTARY-2" urn="urn:adsk.eagle:symbol:40102/1" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;</description>
-<wire x1="1.905" y1="0" x2="2.54" y2="0" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="0" x2="1.905" y2="1.27" width="0.254" layer="94"/>
-<circle x="-2.54" y="0" radius="0.127" width="0.4064" layer="94"/>
-<circle x="2.54" y="0" radius="0.127" width="0.4064" layer="94"/>
-<text x="0" y="1.524" size="1.778" layer="95" font="vector" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.508" size="1.778" layer="96" font="vector" align="top-center">&gt;VALUE</text>
-<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="2"/>
-<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="MOMENTARY-SWITCH-SPST" urn="urn:adsk.eagle:component:40205/1" prefix="S" library_version="1">
-<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST&lt;/h3&gt;
-&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;h4&gt;Variants&lt;/h4&gt;
-&lt;h5&gt;PTH-12MM - 12mm square, through-hole&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/9190"&gt;Momentary Pushbutton Switch - 12mm Square&lt;/a&gt; (COM-09190)&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;PTH-6.0MM, PTH-6.0MM-KIT - 6.0mm square, through-hole&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/97"&gt;Mini Pushbutton Switch&lt;/a&gt; (COM-00097)&lt;/li&gt;
-&lt;li&gt;KIT package intended for soldering kit's - only one side of pads' copper is exposed.&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;PTH-RIGHT-ANGLE-KIT - Right-angle, through-hole&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/10791"&gt;Right Angle Tactile Button&lt;/a&gt; - Used on &lt;a href="https://www.sparkfun.com/products/11734"&gt;
-SparkFun BigTime Watch Kit&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;SMD-12MM - 12mm square, surface-mount&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/12993"&gt;Tactile Button - SMD (12mm)&lt;/a&gt; (COM-12993)&lt;/li&gt;
-&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/11888"&gt;SparkFun PicoBoard&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;SMD-4.5MM - 4.5mm Square Trackball Switch&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/13169"&gt;SparkFun Blackberry Trackballer Breakout&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;SMD-4.6MMX2.8MM -  4.60mm x 2.80mm, surface mount&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/13664"&gt;SparkFun SAMD21 Mini Breakout&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;SMD-5.2MM, SMD-5.2-REDUNDANT - 5.2mm square, surface-mount&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/8720"&gt;Mini Pushbutton Switch - SMD&lt;/a&gt; (COM-08720)&lt;/li&gt;
-&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/11114"&gt;Arduino Pro Mini&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;REDUNDANT package connects both switch circuits together&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;SMD-6.0X3.5MM - 6.0 x 3.5mm, surface mount&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/8229"&gt;Momentary Reset Switch SMD&lt;/a&gt; (COM-08229)&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;SMD-6.2MM-TALL - 6.2mm square, surface mount&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/12992"&gt;Tactile Button - SMD (6mm)&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/12651"&gt;SparkFun Digital Sandbox&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
-&lt;h5&gt;SMD-RIGHT-ANGLE - Right-angle, surface mount&lt;/h5&gt;
-&lt;ul&gt;&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/13036"&gt;SparkFun Block for Intel® Edison - Arduino&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</description>
-<gates>
-<gate name="G$1" symbol="SWITCH-MOMENTARY-2" x="0" y="0"/>
-</gates>
-<devices>
-<device name="-PTH-6.0MM" package="TACTILE_SWITCH_PTH_6.0MM">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="3"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40163/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value=" SWCH-08441"/>
-<attribute name="SF_SKU" value="COM-00097"/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-4.5MM" package="TACTILE_SWITCH_SMD_4.5MM">
-<connects>
-<connect gate="G$1" pin="1" pad="2 3"/>
-<connect gate="G$1" pin="2" pad="1 4"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40162/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-09213"/>
-</technology>
-</technologies>
-</device>
-<device name="-PTH-12MM" package="TACTILE_SWITCH_PTH_12MM">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="3"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40164/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-09185"/>
-<attribute name="SF_SKU" value="COM-09190"/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-6.0X3.5MM" package="TACTILE_SWITCH_SMD_6.0X3.5MM">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40165/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-00815"/>
-<attribute name="SF_SKU" value="COM-08229"/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-6.2MM-TALL" package="TACTILE_SWITCH_SMD_6.2MM_TALL">
-<connects>
-<connect gate="G$1" pin="1" pad="A2"/>
-<connect gate="G$1" pin="2" pad="B2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40172/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-11966"/>
-<attribute name="SF_SKU" value="COM-12992"/>
-</technology>
-</technologies>
-</device>
-<device name="-PTH-RIGHT-ANGLE-KIT" package="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40168/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="CONN-10672"/>
-<attribute name="SF_SKU" value="COM-10791"/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-12MM" package="TACTILE_SWITCH_SMD_12MM">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="3"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40166/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-11967"/>
-<attribute name="SF_SKU" value="COM-12993"/>
-</technology>
-</technologies>
-</device>
-<device name="-PTH-6.0MM-KIT" package="TACTILE_SWITCH_PTH_6.0MM_KIT">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="3"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40170/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-08441"/>
-<attribute name="SF_SKU" value="COM-00097 "/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-5.2MM" package="TACTILE_SWITCH_SMD_5.2MM">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="3"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40167/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-08247"/>
-<attribute name="SF_SKU" value="COM-08720"/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-5.2-REDUNDANT" package="TACTILE_SWITCH_SMD_5.2MM">
-<connects>
-<connect gate="G$1" pin="1" pad="1 2"/>
-<connect gate="G$1" pin="2" pad="3 4"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40167/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-08247"/>
-<attribute name="SF_SKU" value="COM-08720"/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-RIGHT-ANGLE" package="TACTILE_SWITCH_SMD_RIGHT_ANGLE">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40169/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="COMP-12265" constant="no"/>
-</technology>
-</technologies>
-</device>
-<device name="-SMD-4.6X2.8MM" package="TACTILE_SWITCH_SMD_4.6X2.8MM">
-<connects>
-<connect gate="G$1" pin="1" pad="1 2"/>
-<connect gate="G$1" pin="2" pad="3 4"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:40176/1"/>
-</package3dinstances>
-<technologies>
-<technology name="">
-<attribute name="PROD_ID" value="SWCH-13065"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
-<library name="bens">
-<packages>
-<package name="CHIPANTENNA-1206">
-<circle x="-0.7" y="0" radius="0.360553125" width="0.127" layer="21"/>
-<rectangle x1="1.75" y1="-0.9" x2="4.25" y2="0.9" layer="1"/>
-<rectangle x1="-1.75" y1="-0.9" x2="1.75" y2="0.9" layer="51"/>
-<rectangle x1="-3.75" y1="-0.9" x2="-1.75" y2="0.9" layer="1"/>
-<wire x1="-3.75" y1="4" x2="-3.75" y2="-4" width="0.0762" layer="51"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="1"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="1"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="31"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="31"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="29"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="29"/>
-<smd name="P$1" x="-3.7" y="0" dx="0.1" dy="1.8" layer="1" stop="no" thermals="no" cream="no"/>
-<text x="-3" y="1.3" size="0.4" layer="51" rot="R90">GND Line</text>
-</package>
-<package name="CHIPANTENNA-1206-SHORT">
-<circle x="-0.7" y="0" radius="0.360553125" width="0.127" layer="21"/>
-<rectangle x1="-1.75" y1="-0.9" x2="1.75" y2="0.9" layer="51"/>
-<rectangle x1="-3.75" y1="-0.9" x2="-1.75" y2="0.9" layer="1"/>
-<wire x1="-3.75" y1="4" x2="-3.75" y2="-4" width="0.0762" layer="51"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="1"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="1"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="31"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="31"/>
-<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="29"/>
-<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="29"/>
-<smd name="P$1" x="-3.7" y="0" dx="0.1" dy="1.8" layer="1" stop="no" thermals="no" cream="no"/>
-<text x="-3" y="1.3" size="0.4" layer="51" rot="R90">GND Line</text>
-</package>
-<package name="PICO-D4-QFN48">
+<package name="PICO-D4-QFN48" urn="urn:adsk.eagle:footprint:35450557/1" library_version="3">
 <description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
 48 Quad Flat Package No Leads&lt;br&gt;
 Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
@@ -4125,10 +3435,59 @@ Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description
 <text x="-3" y="4" size="1.27" layer="25">&gt;NAME</text>
 <text x="-3" y="-5" size="1.27" layer="27">&gt;VALUE</text>
 </package>
-<package name="QFN48">
+<package name="QFN48" urn="urn:adsk.eagle:footprint:35450558/1" library_version="3">
 <description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
 48 Quad Flat Package No Leads&lt;br&gt;
 Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
+<circle x="-3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.5" y="2.5" radius="0.4" width="0" layer="51"/>
 <wire x1="-3" y1="3.5" x2="3" y2="3.5" width="0.1016" layer="51"/>
 <wire x1="3" y1="3.5" x2="3.5" y2="3" width="0.1016" layer="51"/>
 <wire x1="3.5" y1="3" x2="3.5" y2="-3" width="0.1016" layer="51"/>
@@ -4617,106 +3976,10 @@ Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description
 <wire x1="-2.845" y1="3.055" x2="-2.845" y2="3.495" width="0.1016" layer="29"/>
 <wire x1="-2.845" y1="3.495" x2="-2.655" y2="3.495" width="0.1016" layer="29"/>
 <wire x1="-2.75" y1="3.445" x2="-2.75" y2="3.105" width="0.1016" layer="29"/>
-<circle x="-3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="-3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
-<circle x="3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
-<circle x="2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
-<circle x="-2.5" y="2.5" radius="0.4" width="0" layer="51"/>
-<smd name="EXP" x="0" y="0" dx="4.575" dy="4.575" layer="1" roundness="5" stop="no" cream="no"/>
-<smd name="1" x="-3.275" y="2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="2" x="-3.275" y="2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="3" x="-3.275" y="1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="4" x="-3.275" y="1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="5" x="-3.275" y="0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="6" x="-3.275" y="0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="7" x="-3.275" y="-0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="8" x="-3.275" y="-0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="9" x="-3.275" y="-1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="10" x="-3.275" y="-1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="11" x="-3.275" y="-2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="12" x="-3.275" y="-2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
-<smd name="13" x="-2.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="14" x="-2.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="15" x="-1.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="16" x="-1.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="17" x="-0.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="18" x="-0.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="19" x="0.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="20" x="0.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="21" x="1.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="22" x="1.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="23" x="2.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="24" x="2.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
-<smd name="25" x="3.275" y="-2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="26" x="3.275" y="-2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="27" x="3.275" y="-1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="28" x="3.275" y="-1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="29" x="3.275" y="-0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="30" x="3.275" y="-0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="31" x="3.275" y="0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="32" x="3.275" y="0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="33" x="3.275" y="1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="34" x="3.275" y="1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="35" x="3.275" y="2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="36" x="3.275" y="2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
-<smd name="37" x="2.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="38" x="2.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="39" x="1.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="40" x="1.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="41" x="0.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="42" x="0.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="43" x="-0.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="44" x="-0.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="45" x="-1.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="46" x="-1.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="47" x="-2.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<smd name="48" x="-2.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
-<text x="-3" y="4" size="1.27" layer="25">&gt;NAME</text>
-<text x="-3" y="-5" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-3.556" y1="3.556" x2="3.556" y2="3.556" width="0.127" layer="21"/>
+<wire x1="3.556" y1="3.556" x2="3.556" y2="-3.556" width="0.127" layer="21"/>
+<wire x1="3.556" y1="-3.556" x2="-3.556" y2="-3.556" width="0.127" layer="21"/>
+<wire x1="-3.556" y1="-3.556" x2="-3.556" y2="3.556" width="0.127" layer="21"/>
 <rectangle x1="-3.45" y1="2.535" x2="-3.22" y2="2.965" layer="51" rot="R270"/>
 <rectangle x1="-3.45" y1="2.035" x2="-3.22" y2="2.465" layer="51" rot="R270"/>
 <rectangle x1="-3.45" y1="1.535" x2="-3.22" y2="1.965" layer="51" rot="R270"/>
@@ -4774,118 +4037,757 @@ Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description
 <rectangle x1="0.616" y1="-0.254" x2="1.886" y2="0.254" layer="31"/>
 <rectangle x1="-0.254" y1="-1.886" x2="0.254" y2="-0.616" layer="31"/>
 <rectangle x1="-0.254" y1="0.616" x2="0.254" y2="1.886" layer="31"/>
-<wire x1="-3.048" y1="3.556" x2="3.556" y2="3.556" width="0.127" layer="21"/>
-<wire x1="3.556" y1="3.556" x2="3.556" y2="-3.556" width="0.127" layer="21"/>
-<wire x1="3.556" y1="-3.556" x2="-3.556" y2="-3.556" width="0.127" layer="21"/>
-<wire x1="-3.556" y1="-3.556" x2="-3.556" y2="3.556" width="0.127" layer="21"/>
-<wire x1="-3.556" y1="3.556" x2="-3.048" y2="3.556" width="0.127" layer="21"/>
+<smd name="1" x="-3.275" y="2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="2" x="-3.275" y="2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="3" x="-3.275" y="1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="4" x="-3.275" y="1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="5" x="-3.275" y="0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="6" x="-3.275" y="0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="7" x="-3.275" y="-0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="8" x="-3.275" y="-0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="9" x="-3.275" y="-1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="10" x="-3.275" y="-1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="11" x="-3.275" y="-2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="12" x="-3.275" y="-2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="13" x="-2.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="14" x="-2.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="15" x="-1.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="16" x="-1.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="17" x="-0.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="18" x="-0.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="19" x="0.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="20" x="0.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="21" x="1.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="22" x="1.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="23" x="2.25" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="24" x="2.75" y="-3.275" dx="0.3" dy="0.55" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="25" x="3.275" y="-2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="26" x="3.275" y="-2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="27" x="3.275" y="-1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="28" x="3.275" y="-1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="29" x="3.275" y="-0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="30" x="3.275" y="-0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="31" x="3.275" y="0.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="32" x="3.275" y="0.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="33" x="3.275" y="1.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="34" x="3.275" y="1.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="35" x="3.275" y="2.25" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="36" x="3.275" y="2.75" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="37" x="2.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="38" x="2.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="39" x="1.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="40" x="1.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="41" x="0.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="42" x="0.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="43" x="-0.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="44" x="-0.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="45" x="-1.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="46" x="-1.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="47" x="-2.25" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="48" x="-2.75" y="3.275" dx="0.3" dy="0.55" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="EXP" x="0" y="0" dx="4.575" dy="4.575" layer="1" roundness="5" stop="no" cream="no"/>
+<text x="-3" y="4" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3" y="-5" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="SOP50P310X90-8N" urn="urn:adsk.eagle:footprint:35450555/2" library_version="3">
+<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="21"/>
+<circle x="-2.525" y="1.02" radius="0.2" width="0" layer="51"/>
+<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="51"/>
+<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="51"/>
+<wire x1="-1.15" y1="1" x2="1.15" y2="1" width="0.127" layer="21"/>
+<wire x1="-1.15" y1="-1" x2="1.15" y2="-1" width="0.127" layer="21"/>
+<wire x1="-1.15" y1="1" x2="-1.15" y2="-1" width="0.127" layer="51"/>
+<wire x1="1.15" y1="1" x2="1.15" y2="-1" width="0.127" layer="51"/>
+<wire x1="-2.215" y1="1.25" x2="2.215" y2="1.25" width="0.05" layer="39"/>
+<wire x1="-2.215" y1="-1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
+<wire x1="-2.215" y1="1.25" x2="-2.215" y2="-1.25" width="0.05" layer="39"/>
+<wire x1="2.215" y1="1.25" x2="2.215" y2="-1.25" width="0.05" layer="39"/>
+<smd name="1" x="-1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="2" x="-1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="3" x="-1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="4" x="-1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="5" x="1.405" y="-0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="6" x="1.405" y="-0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="7" x="1.405" y="0.25" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<smd name="8" x="1.405" y="0.75" dx="1.12" dy="0.27" layer="1" roundness="25"/>
+<text x="0" y="0" size="1" layer="25" font="vector" align="center">&gt;NAME</text>
+</package>
+<package name="SOT23-5" urn="urn:adsk.eagle:footprint:35450556/1" library_version="3">
+<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt;</description>
+<circle x="-1.6002" y="-1.016" radius="0.127" width="0" layer="21"/>
+<wire x1="1.27" y1="0.4294" x2="1.27" y2="-0.4294" width="0.2032" layer="21"/>
+<wire x1="1.4" y1="-0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
+<wire x1="-1.27" y1="-0.4294" x2="-1.27" y2="0.4294" width="0.2032" layer="21"/>
+<wire x1="-1.4" y1="0.8" x2="1.4" y2="0.8" width="0.1524" layer="51"/>
+<wire x1="-0.2684" y1="0.7088" x2="0.2684" y2="0.7088" width="0.2032" layer="21"/>
+<wire x1="1.4" y1="0.8" x2="1.4" y2="-0.8" width="0.1524" layer="51"/>
+<wire x1="-1.4" y1="0.8" x2="-1.4" y2="-0.8" width="0.1524" layer="51"/>
+<rectangle x1="-1.2" y1="-1.5" x2="-0.7" y2="-0.85" layer="51"/>
+<rectangle x1="-0.25" y1="-1.5" x2="0.25" y2="-0.85" layer="51"/>
+<rectangle x1="0.7" y1="-1.5" x2="1.2" y2="-0.85" layer="51"/>
+<rectangle x1="0.7" y1="0.85" x2="1.2" y2="1.5" layer="51"/>
+<rectangle x1="-1.2" y1="0.85" x2="-0.7" y2="1.5" layer="51"/>
+<smd name="1" x="-0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="2" x="0" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="3" x="0.95" y="-1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="4" x="0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
+<smd name="5" x="-0.95" y="1.3001" dx="0.55" dy="1.2" layer="1"/>
+<text x="-0.889" y="2.159" size="0.4064" layer="25">&gt;NAME</text>
+<text x="-0.9525" y="-0.1905" size="0.4064" layer="27">&gt;VALUE</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:footprint:35450548/2" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/Buttons/SMD-Button.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<circle x="0" y="0" radius="1.27" width="0.2032" layer="21"/>
+<wire x1="-1.54" y1="-2.54" x2="-2.54" y2="-1.54" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-1.24" x2="-2.54" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="1.54" x2="-1.54" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="-1.54" y1="2.54" x2="1.54" y2="2.54" width="0.2032" layer="21"/>
+<wire x1="1.54" y1="2.54" x2="2.54" y2="1.54" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="1.24" x2="2.54" y2="-1.24" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-1.54" x2="1.54" y2="-2.54" width="0.2032" layer="51"/>
+<wire x1="1.54" y1="-2.54" x2="-1.54" y2="-2.54" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="1.905" y2="0.445" width="0.127" layer="51"/>
+<wire x1="1.905" y1="0.445" x2="2.16" y2="-0.01" width="0.127" layer="51"/>
+<wire x1="1.905" y1="-0.23" x2="1.905" y2="-1.115" width="0.127" layer="51"/>
+<smd name="1" x="-2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<smd name="2" x="2.794" y="1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<smd name="3" x="-2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<smd name="4" x="2.794" y="-1.905" dx="0.762" dy="1.524" layer="1" rot="R90"/>
+<text x="0" y="0" size="1" layer="25" font="vector" ratio="12" align="center">&gt;NAME</text>
+</package>
+<package name="TACTILE_SWITCH_PTH_6.0MM" urn="urn:adsk.eagle:footprint:35450554/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-1000)&lt;/p&gt;</description>
+<circle x="0" y="0" radius="1.778" width="0.2032" layer="21"/>
+<wire x1="3.048" y1="1.016" x2="3.048" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="3.048" y1="2.54" x2="2.54" y2="3.048" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="-3.048" x2="3.048" y2="-2.54" width="0.2032" layer="51"/>
+<wire x1="3.048" y1="-2.54" x2="3.048" y2="-1.016" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="3.048" x2="-3.048" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="-3.048" y1="2.54" x2="-3.048" y2="1.016" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-3.048" x2="-3.048" y2="-2.54" width="0.2032" layer="51"/>
+<wire x1="-3.048" y1="-2.54" x2="-3.048" y2="-1.016" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-3.048" x2="-2.159" y2="-3.048" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="3.048" x2="2.159" y2="3.048" width="0.2032" layer="51"/>
+<wire x1="2.159" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="21"/>
+<wire x1="-2.159" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="21"/>
+<wire x1="3.048" y1="0.998" x2="3.048" y2="-1.016" width="0.2032" layer="21"/>
+<wire x1="-3.048" y1="1.028" x2="-3.048" y2="-1.016" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="1.27" x2="-2.54" y2="0.508" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-0.508" x2="-2.54" y2="-1.27" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="0.508" x2="-2.159" y2="-0.381" width="0.2032" layer="51"/>
+<pad name="1" x="-3.2512" y="2.2606" drill="1.016" diameter="1.8796"/>
+<pad name="2" x="3.2512" y="2.2606" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="-3.2512" y="-2.2606" drill="1.016" diameter="1.8796"/>
+<pad name="4" x="3.2512" y="-2.2606" drill="1.016" diameter="1.8796"/>
+<text x="0" y="3.302" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-3.175" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_PTH_6.0MM_KIT" urn="urn:adsk.eagle:footprint:35450553/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-1000)&lt;/p&gt;</description>
+<circle x="0" y="0" radius="1.778" width="0.2032" layer="21"/>
+<wire x1="3.048" y1="1.016" x2="3.048" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="3.048" y1="2.54" x2="2.54" y2="3.048" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="-3.048" x2="3.048" y2="-2.54" width="0.2032" layer="51"/>
+<wire x1="3.048" y1="-2.54" x2="3.048" y2="-1.016" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="3.048" x2="-3.048" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="-3.048" y1="2.54" x2="-3.048" y2="1.016" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-3.048" x2="-3.048" y2="-2.54" width="0.2032" layer="51"/>
+<wire x1="-3.048" y1="-2.54" x2="-3.048" y2="-1.016" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-3.048" x2="-2.159" y2="-3.048" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="3.048" x2="2.159" y2="3.048" width="0.2032" layer="51"/>
+<wire x1="2.159" y1="3.048" x2="-2.159" y2="3.048" width="0.2032" layer="21"/>
+<wire x1="-2.159" y1="-3.048" x2="2.159" y2="-3.048" width="0.2032" layer="21"/>
+<wire x1="3.048" y1="0.998" x2="3.048" y2="-1.016" width="0.2032" layer="21"/>
+<wire x1="-3.048" y1="1.028" x2="-3.048" y2="-1.016" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="1.27" x2="-2.54" y2="0.508" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="-0.508" x2="-2.54" y2="-1.27" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="0.508" x2="-2.159" y2="-0.381" width="0.2032" layer="51"/>
+<pad name="1" x="-3.2512" y="2.2606" drill="1.016" diameter="1.8796" stop="no"/>
+<pad name="2" x="3.2512" y="2.2606" drill="1.016" diameter="1.8796" stop="no"/>
+<pad name="3" x="-3.2512" y="-2.2606" drill="1.016" diameter="1.8796" stop="no"/>
+<pad name="4" x="3.2512" y="-2.2606" drill="1.016" diameter="1.8796" stop="no"/>
+<text x="0" y="3.175" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-3.175" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+<polygon width="0.127" layer="30">
+<vertex x="-3.2664" y="3.142"/>
+<vertex x="-3.2589" y="3.1445" curve="89.986886"/>
+<vertex x="-4.1326" y="2.286"/>
+<vertex x="-4.1351" y="2.2657" curve="90.00652"/>
+<vertex x="-3.2563" y="1.392"/>
+<vertex x="-3.2487" y="1.3869" curve="90.006616"/>
+<vertex x="-2.3826" y="2.2403"/>
+<vertex x="-2.3775" y="2.2683" curve="89.98711"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="-3.2462" y="2.7026"/>
+<vertex x="-3.2589" y="2.7051" curve="90.026544"/>
+<vertex x="-3.6881" y="2.2733"/>
+<vertex x="-3.6881" y="2.2632" curve="89.974074"/>
+<vertex x="-3.2562" y="1.8213"/>
+<vertex x="-3.2259" y="1.8186" curve="90.051271"/>
+<vertex x="-2.8093" y="2.2658"/>
+<vertex x="-2.8093" y="2.2606" curve="90.012964"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="3.2411" y="3.1395"/>
+<vertex x="3.2486" y="3.142" curve="89.986886"/>
+<vertex x="2.3749" y="2.2835"/>
+<vertex x="2.3724" y="2.2632" curve="90.00652"/>
+<vertex x="3.2512" y="1.3895"/>
+<vertex x="3.2588" y="1.3844" curve="90.006616"/>
+<vertex x="4.1249" y="2.2378"/>
+<vertex x="4.13" y="2.2658" curve="89.98711"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="3.2613" y="2.7001"/>
+<vertex x="3.2486" y="2.7026" curve="90.026544"/>
+<vertex x="2.8194" y="2.2708"/>
+<vertex x="2.8194" y="2.2607" curve="89.974074"/>
+<vertex x="3.2513" y="1.8188"/>
+<vertex x="3.2816" y="1.8161" curve="90.051271"/>
+<vertex x="3.6982" y="2.2633"/>
+<vertex x="3.6982" y="2.2581" curve="90.012964"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="-3.2613" y="-1.3868"/>
+<vertex x="-3.2538" y="-1.3843" curve="89.986886"/>
+<vertex x="-4.1275" y="-2.2428"/>
+<vertex x="-4.13" y="-2.2631" curve="90.00652"/>
+<vertex x="-3.2512" y="-3.1368"/>
+<vertex x="-3.2436" y="-3.1419" curve="90.006616"/>
+<vertex x="-2.3775" y="-2.2885"/>
+<vertex x="-2.3724" y="-2.2605" curve="89.98711"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="-3.2411" y="-1.8262"/>
+<vertex x="-3.2538" y="-1.8237" curve="90.026544"/>
+<vertex x="-3.683" y="-2.2555"/>
+<vertex x="-3.683" y="-2.2656" curve="89.974074"/>
+<vertex x="-3.2511" y="-2.7075"/>
+<vertex x="-3.2208" y="-2.7102" curve="90.051271"/>
+<vertex x="-2.8042" y="-2.263"/>
+<vertex x="-2.8042" y="-2.2682" curve="90.012964"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="3.2411" y="-1.3843"/>
+<vertex x="3.2486" y="-1.3818" curve="89.986886"/>
+<vertex x="2.3749" y="-2.2403"/>
+<vertex x="2.3724" y="-2.2606" curve="90.00652"/>
+<vertex x="3.2512" y="-3.1343"/>
+<vertex x="3.2588" y="-3.1394" curve="90.006616"/>
+<vertex x="4.1249" y="-2.286"/>
+<vertex x="4.13" y="-2.258" curve="89.98711"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="3.2613" y="-1.8237"/>
+<vertex x="3.2486" y="-1.8212" curve="90.026544"/>
+<vertex x="2.8194" y="-2.253"/>
+<vertex x="2.8194" y="-2.2631" curve="89.974074"/>
+<vertex x="3.2513" y="-2.705"/>
+<vertex x="3.2816" y="-2.7077" curve="90.051271"/>
+<vertex x="3.6982" y="-2.2605"/>
+<vertex x="3.6982" y="-2.2657" curve="90.012964"/>
+</polygon>
+</package>
+<package name="TACTILE_SWITCH_PTH_12MM" urn="urn:adsk.eagle:footprint:35450552/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 12mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-5050)&lt;/p&gt;</description>
+<circle x="0" y="0" radius="3.5" width="0.2032" layer="21"/>
+<circle x="-4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
+<circle x="4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
+<circle x="4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
+<circle x="-4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
+<wire x1="5" y1="-1.3" x2="5" y2="-0.7" width="0.2032" layer="51"/>
+<wire x1="5" y1="-0.7" x2="4.5" y2="-0.2" width="0.2032" layer="51"/>
+<wire x1="5" y1="0.2" x2="5" y2="1" width="0.2032" layer="51"/>
+<wire x1="-6" y1="4" x2="-6" y2="5" width="0.2032" layer="21"/>
+<wire x1="-5" y1="6" x2="5" y2="6" width="0.2032" layer="21"/>
+<wire x1="6" y1="5" x2="6" y2="4" width="0.2032" layer="21"/>
+<wire x1="6" y1="1" x2="6" y2="-1" width="0.2032" layer="21"/>
+<wire x1="6" y1="-4" x2="6" y2="-5" width="0.2032" layer="21"/>
+<wire x1="5" y1="-6" x2="-5" y2="-6" width="0.2032" layer="21"/>
+<wire x1="-6" y1="-5" x2="-6" y2="-4" width="0.2032" layer="21"/>
+<wire x1="-6" y1="-1" x2="-6" y2="1" width="0.2032" layer="21"/>
+<wire x1="-6" y1="5" x2="-5" y2="6" width="0.2032" layer="21" curve="-90"/>
+<wire x1="5" y1="6" x2="6" y2="5" width="0.2032" layer="21" curve="-90"/>
+<wire x1="6" y1="-5" x2="5" y2="-6" width="0.2032" layer="21" curve="-90"/>
+<wire x1="-5" y1="-6" x2="-6" y2="-5" width="0.2032" layer="21" curve="-90"/>
+<pad name="1" x="6.25" y="-2.5" drill="1.2" diameter="2.159"/>
+<pad name="2" x="-6.25" y="-2.5" drill="1.2" diameter="2.159"/>
+<pad name="3" x="6.25" y="2.5" drill="1.2" diameter="2.159"/>
+<pad name="4" x="-6.25" y="2.5" drill="1.2" diameter="2.159"/>
+<text x="0" y="6.223" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-6.223" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT" urn="urn:adsk.eagle:footprint:35450551/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, Right-angle&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://cdn.sparkfun.com/datasheets/Components/Switches/SW016.JPG"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<circle x="2.5" y="0" radius="0.4445" width="0" layer="29"/>
+<circle x="-2.5" y="0" radius="0.4445" width="0" layer="29"/>
+<circle x="-3.5" y="2.5" radius="0.635" width="0" layer="29"/>
+<circle x="3.5" y="2.5" radius="0.635" width="0" layer="29"/>
+<circle x="-3.5" y="2.5" radius="1.143" width="0" layer="30"/>
+<circle x="2.5" y="0" radius="0.889" width="0" layer="30"/>
+<circle x="-2.5" y="0" radius="0.889" width="0" layer="30"/>
+<circle x="3.5" y="2.5" radius="1.143" width="0" layer="30"/>
+<wire x1="1.5" y1="-3.8" x2="-1.5" y2="-3.8" width="0.127" layer="51"/>
+<wire x1="-3.65" y1="-2" x2="-3.65" y2="3.5" width="0.127" layer="51"/>
+<wire x1="-3.65" y1="3.5" x2="-3" y2="3.5" width="0.127" layer="51"/>
+<wire x1="3" y1="3.5" x2="3.65" y2="3.5" width="0.127" layer="51"/>
+<wire x1="3.65" y1="3.5" x2="3.65" y2="-2" width="0.127" layer="51"/>
+<wire x1="-3" y1="2" x2="3" y2="2" width="0.127" layer="51"/>
+<wire x1="-3" y1="2" x2="-3" y2="3.5" width="0.127" layer="51"/>
+<wire x1="3" y1="2" x2="3" y2="3.5" width="0.127" layer="51"/>
+<wire x1="-3.65" y1="-2" x2="-1.5" y2="-2" width="0.127" layer="51"/>
+<wire x1="-1.5" y1="-2" x2="1.5" y2="-2" width="0.127" layer="51"/>
+<wire x1="1.5" y1="-2" x2="3.65" y2="-2" width="0.127" layer="51"/>
+<wire x1="1.5" y1="-2" x2="1.5" y2="-3.8" width="0.127" layer="51"/>
+<wire x1="-1.5" y1="-2" x2="-1.5" y2="-3.8" width="0.127" layer="51"/>
+<wire x1="-3.777" y1="1" x2="-3.777" y2="-2.127" width="0.2032" layer="21"/>
+<wire x1="-3.777" y1="-2.127" x2="3.777" y2="-2.127" width="0.2032" layer="21"/>
+<wire x1="3.777" y1="-2.127" x2="3.777" y2="1" width="0.2032" layer="21"/>
+<wire x1="2" y1="2.127" x2="-2" y2="2.127" width="0.2032" layer="21"/>
+<pad name="1" x="-2.5" y="0" drill="0.8" diameter="1.7" stop="no"/>
+<pad name="2" x="2.5" y="0" drill="0.8" diameter="1.7" stop="no"/>
+<pad name="ANCHOR1" x="-3.5" y="2.5" drill="1.2" diameter="2.2" stop="no"/>
+<pad name="ANCHOR2" x="3.5" y="2.5" drill="1.2" diameter="2.2" stop="no"/>
+<text x="0" y="2.286" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_4.5MM" urn="urn:adsk.eagle:footprint:35450550/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 4.5mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://spec_sheets.e-switch.com/specs/P010338.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<circle x="0" y="0" radius="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="1.905" y2="0.445" width="0.127" layer="51"/>
+<wire x1="1.905" y1="0.445" x2="2.16" y2="-0.01" width="0.127" layer="51"/>
+<wire x1="1.905" y1="-0.23" x2="1.905" y2="-1.115" width="0.127" layer="51"/>
+<wire x1="-2.25" y1="2.25" x2="2.25" y2="2.25" width="0.127" layer="51"/>
+<wire x1="2.25" y1="2.25" x2="2.25" y2="-2.25" width="0.127" layer="51"/>
+<wire x1="2.25" y1="-2.25" x2="-2.25" y2="-2.25" width="0.127" layer="51"/>
+<wire x1="-2.25" y1="-2.25" x2="-2.25" y2="2.25" width="0.127" layer="51"/>
+<wire x1="-2.2" y1="0.8" x2="-2.2" y2="-0.8" width="0.2032" layer="21"/>
+<wire x1="1.3" y1="2.2" x2="-1.3" y2="2.2" width="0.2032" layer="21"/>
+<wire x1="2.2" y1="-0.8" x2="2.2" y2="0.8" width="0.2032" layer="21"/>
+<wire x1="-1.3" y1="-2.2" x2="1.3" y2="-2.2" width="0.2032" layer="21"/>
+<wire x1="2.2" y1="0.8" x2="1.8" y2="0.8" width="0.2032" layer="21"/>
+<wire x1="2.2" y1="-0.8" x2="1.8" y2="-0.8" width="0.2032" layer="21"/>
+<wire x1="-1.8" y1="0.8" x2="-2.2" y2="0.8" width="0.2032" layer="21"/>
+<wire x1="-1.8" y1="-0.8" x2="-2.2" y2="-0.8" width="0.2032" layer="21"/>
+<smd name="1" x="2.225" y="1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
+<smd name="2" x="2.225" y="-1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
+<smd name="3" x="-2.225" y="-1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
+<smd name="4" x="-2.225" y="1.75" dx="1.1" dy="0.7" layer="1" rot="R90"/>
+<text x="0" y="2.413" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-2.413" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_4.6X2.8MM" urn="urn:adsk.eagle:footprint:35450549/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 4.6 x 2.8mm&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://www.ck-components.com/media/1479/kmr2.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<circle x="0" y="0" radius="0.805" width="0.127" layer="21"/>
+<wire x1="-2.1" y1="1.4" x2="-2.1" y2="-1.4" width="0.127" layer="51"/>
+<wire x1="2.1" y1="-1.4" x2="2.1" y2="1.4" width="0.127" layer="51"/>
+<wire x1="-2.1" y1="1.4" x2="2.1" y2="1.4" width="0.127" layer="51"/>
+<wire x1="-2.1" y1="-1.4" x2="2.1" y2="-1.4" width="0.127" layer="51"/>
+<wire x1="1.338" y1="-1.4" x2="-1.338" y2="-1.4" width="0.2032" layer="21"/>
+<wire x1="-1.338" y1="1.4" x2="1.338" y2="1.4" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="0.13" x2="-2.1" y2="-0.13" width="0.2032" layer="21"/>
+<wire x1="2.1" y1="-0.13" x2="2.1" y2="0.13" width="0.2032" layer="21"/>
+<rectangle x1="-2.3" y1="0.5" x2="-2.1" y2="1.1" layer="51"/>
+<rectangle x1="-2.3" y1="-1.1" x2="-2.1" y2="-0.5" layer="51"/>
+<rectangle x1="2.1" y1="-1.1" x2="2.3" y2="-0.5" layer="51" rot="R180"/>
+<rectangle x1="2.1" y1="0.5" x2="2.3" y2="1.1" layer="51" rot="R180"/>
+<smd name="1" x="-2.05" y="-0.8" dx="0.9" dy="1" layer="1"/>
+<smd name="2" x="2.05" y="-0.8" dx="0.9" dy="1" layer="1"/>
+<smd name="3" x="2.05" y="0.8" dx="0.9" dy="1" layer="1"/>
+<smd name="4" x="-2.05" y="0.8" dx="0.9" dy="1" layer="1"/>
+<text x="0" y="1.524" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-1.524" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_6.0X3.5MM" urn="urn:adsk.eagle:footprint:35450547/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 6.0 x 3.5 mm&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/1101.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<wire x1="-3" y1="1.1" x2="-3" y2="-1.1" width="0.127" layer="51"/>
+<wire x1="3" y1="1.1" x2="3" y2="-1.1" width="0.127" layer="51"/>
+<wire x1="-2.75" y1="1.75" x2="-3" y2="1.5" width="0.2032" layer="21" curve="90"/>
+<wire x1="-2.75" y1="1.75" x2="2.75" y2="1.75" width="0.2032" layer="21"/>
+<wire x1="2.75" y1="1.75" x2="3" y2="1.5" width="0.2032" layer="21" curve="-90"/>
+<wire x1="3" y1="-1.5" x2="2.75" y2="-1.75" width="0.2032" layer="21" curve="-90"/>
+<wire x1="2.75" y1="-1.75" x2="-2.75" y2="-1.75" width="0.2032" layer="21"/>
+<wire x1="-3" y1="-1.5" x2="-2.75" y2="-1.75" width="0.2032" layer="21" curve="90"/>
+<wire x1="-3" y1="-1.5" x2="-3" y2="-1.1" width="0.2032" layer="21"/>
+<wire x1="-3" y1="1.1" x2="-3" y2="1.5" width="0.2032" layer="21"/>
+<wire x1="3" y1="1.1" x2="3" y2="1.5" width="0.2032" layer="21"/>
+<wire x1="3" y1="-1.5" x2="3" y2="-1.1" width="0.2032" layer="21"/>
+<wire x1="-1.5" y1="0.75" x2="1.5" y2="0.75" width="0.2032" layer="21"/>
+<wire x1="1.5" y1="-0.75" x2="-1.5" y2="-0.75" width="0.2032" layer="21"/>
+<wire x1="-1.5" y1="-0.75" x2="-1.5" y2="0.75" width="0.2032" layer="21"/>
+<wire x1="1.5" y1="-0.75" x2="1.5" y2="0.75" width="0.2032" layer="21"/>
+<wire x1="-2" y1="0" x2="-1" y2="0" width="0.127" layer="51"/>
+<wire x1="-1" y1="0" x2="0.1" y2="0.5" width="0.127" layer="51"/>
+<wire x1="0.3" y1="0" x2="2" y2="0" width="0.127" layer="51"/>
+<smd name="1" x="-3.15" y="0" dx="2.3" dy="1.6" layer="1" rot="R180"/>
+<smd name="2" x="3.15" y="0" dx="2.3" dy="1.6" layer="1" rot="R180"/>
+<text x="0" y="1.905" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-1.905" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_6.2MM_TALL" urn="urn:adsk.eagle:footprint:35450546/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 6.2mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://www.apem.com/files/apem/brochures/ADTS6-ADTSM-KTSC6.pdf"&gt;Datasheet&lt;/a&gt; (ADTSM63NVTR)&lt;/p&gt;</description>
+<circle x="0" y="0" radius="1.75" width="0.2032" layer="21"/>
+<wire x1="-3" y1="-3" x2="3" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3" y1="-3" x2="3" y2="3" width="0.2032" layer="21"/>
+<wire x1="3" y1="3" x2="-3" y2="3" width="0.2032" layer="21"/>
+<wire x1="-3" y1="3" x2="-3" y2="-3" width="0.2032" layer="21"/>
+<smd name="A1" x="-3.975" y="-2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
+<smd name="A2" x="3.975" y="-2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
+<smd name="B1" x="-3.975" y="2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
+<smd name="B2" x="3.975" y="2.25" dx="1.3" dy="1.55" layer="1" rot="R90"/>
+<text x="0" y="3.175" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-3.175" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_12MM" urn="urn:adsk.eagle:footprint:35450545/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 12mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://cdn.sparkfun.com/datasheets/Components/Switches/N301102.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<circle x="0" y="0" radius="3.5" width="0.2032" layer="21"/>
+<circle x="-4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
+<circle x="4.5" y="4.5" radius="0.3" width="0.7" layer="21"/>
+<circle x="4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
+<circle x="-4.5" y="-4.5" radius="0.3" width="0.7" layer="21"/>
+<wire x1="5" y1="-1.3" x2="5" y2="-0.7" width="0.2032" layer="51"/>
+<wire x1="5" y1="-0.7" x2="4.5" y2="-0.2" width="0.2032" layer="51"/>
+<wire x1="5" y1="0.2" x2="5" y2="1" width="0.2032" layer="51"/>
+<wire x1="-6" y1="4" x2="-6" y2="5" width="0.2032" layer="21"/>
+<wire x1="-5" y1="6" x2="5" y2="6" width="0.2032" layer="21"/>
+<wire x1="6" y1="5" x2="6" y2="4" width="0.2032" layer="21"/>
+<wire x1="6" y1="1" x2="6" y2="-1" width="0.2032" layer="21"/>
+<wire x1="6" y1="-4" x2="6" y2="-5" width="0.2032" layer="21"/>
+<wire x1="5" y1="-6" x2="-5" y2="-6" width="0.2032" layer="21"/>
+<wire x1="-6" y1="-5" x2="-6" y2="-4" width="0.2032" layer="21"/>
+<wire x1="-6" y1="-1" x2="-6" y2="1" width="0.2032" layer="21"/>
+<wire x1="-6" y1="-5" x2="-5" y2="-6" width="0.2032" layer="21"/>
+<wire x1="6" y1="-5" x2="5" y2="-6" width="0.2032" layer="21"/>
+<wire x1="6" y1="5" x2="5" y2="6" width="0.2032" layer="21"/>
+<wire x1="-5" y1="6" x2="-6" y2="5" width="0.2032" layer="21"/>
+<smd name="1" x="6.975" y="-2.5" dx="1.6" dy="1.55" layer="1"/>
+<smd name="2" x="-6.975" y="-2.5" dx="1.6" dy="1.55" layer="1"/>
+<smd name="3" x="6.975" y="2.5" dx="1.6" dy="1.55" layer="1"/>
+<smd name="4" x="-6.975" y="2.5" dx="1.6" dy="1.55" layer="1"/>
+<text x="0" y="6.223" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-6.223" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="TACTILE_SWITCH_SMD_RIGHT_ANGLE" urn="urn:adsk.eagle:footprint:35450544/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, Right-angle&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;</description>
+<wire x1="-2" y1="1.2" x2="-2" y2="1.5" width="0.2032" layer="21"/>
+<wire x1="-2" y1="1.5" x2="2" y2="1.5" width="0.2032" layer="21"/>
+<wire x1="2" y1="1.5" x2="2" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="-2" y1="-1.2" x2="-2" y2="-1.5" width="0.2032" layer="21"/>
+<wire x1="-2" y1="-1.5" x2="-0.7" y2="-1.5" width="0.2032" layer="21"/>
+<wire x1="-0.7" y1="-1.5" x2="0.7" y2="-1.5" width="0.2032" layer="21"/>
+<wire x1="0.7" y1="-1.5" x2="2" y2="-1.5" width="0.2032" layer="21"/>
+<wire x1="2" y1="-1.5" x2="2" y2="-1.2" width="0.2032" layer="21"/>
+<wire x1="-0.7" y1="-2.1" x2="0.7" y2="-2.1" width="0.2032" layer="21"/>
+<wire x1="0.7" y1="-2.1" x2="0.7" y2="-1.5" width="0.2032" layer="21"/>
+<wire x1="-0.7" y1="-2.1" x2="-0.7" y2="-1.5" width="0.2032" layer="21"/>
+<smd name="1" x="-1.95" y="0" dx="2" dy="1.1" layer="1" rot="R90"/>
+<smd name="2" x="1.95" y="0" dx="2" dy="1.1" layer="1" rot="R90"/>
+<text x="0" y="1.651" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+<hole x="0" y="0.9" drill="0.7"/>
+<hole x="0" y="-0.9" drill="0.7"/>
+</package>
+<package name="CHIPANTENNA-1206-SHORT" urn="urn:adsk.eagle:footprint:35450559/1" library_version="3">
+<circle x="-0.7" y="0" radius="0.360553125" width="0.127" layer="21"/>
+<wire x1="-3.75" y1="4" x2="-3.75" y2="-4" width="0.0762" layer="51"/>
+<rectangle x1="-1.75" y1="-0.9" x2="1.75" y2="0.9" layer="51"/>
+<rectangle x1="-3.75" y1="-0.9" x2="-1.75" y2="0.9" layer="1"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="1"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="1"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="31"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="31"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="29"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="29"/>
+<smd name="P$1" x="-3.7" y="0" dx="0.1" dy="1.8" layer="1" stop="no" thermals="no" cream="no"/>
+<text x="-3" y="1.3" size="0.4" layer="51" rot="R90">GND Line</text>
+</package>
+<package name="CHIPANTENNA-1206" urn="urn:adsk.eagle:footprint:35450560/1" library_version="3">
+<circle x="-0.7" y="0" radius="0.360553125" width="0.127" layer="21"/>
+<wire x1="-3.75" y1="4" x2="-3.75" y2="-4" width="0.0762" layer="51"/>
+<rectangle x1="1.75" y1="-0.9" x2="4.25" y2="0.9" layer="1"/>
+<rectangle x1="-1.75" y1="-0.9" x2="1.75" y2="0.9" layer="51"/>
+<rectangle x1="-3.75" y1="-0.9" x2="-1.75" y2="0.9" layer="1"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="1"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="1"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="31"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="31"/>
+<rectangle x1="-1.75" y1="-0.9" x2="-1.35" y2="0.9" layer="29"/>
+<rectangle x1="1.35" y1="-0.9" x2="1.75" y2="0.9" layer="29"/>
+<smd name="P$1" x="-3.7" y="0" dx="0.1" dy="1.8" layer="1" stop="no" thermals="no" cream="no"/>
+<text x="-3" y="1.3" size="0.4" layer="51" rot="R90">GND Line</text>
 </package>
 </packages>
+<packages3d>
+<package3d name="PICO-D4-QFN48" urn="urn:adsk.eagle:package:35450580/2" type="model" library_version="3">
+<description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
+48 Quad Flat Package No Leads&lt;br&gt;
+Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
+<packageinstances>
+<packageinstance name="PICO-D4-QFN48"/>
+</packageinstances>
+</package3d>
+<package3d name="QFN48" urn="urn:adsk.eagle:package:35450581/1" type="box" library_version="3">
+<description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
+48 Quad Flat Package No Leads&lt;br&gt;
+Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
+<packageinstances>
+<packageinstance name="QFN48"/>
+</packageinstances>
+</package3d>
+<package3d name="SOP50P310X90-8N" urn="urn:adsk.eagle:package:35450578/3" type="model" library_version="3">
+<packageinstances>
+<packageinstance name="SOP50P310X90-8N"/>
+</packageinstances>
+</package3d>
+<package3d name="SOT23-5" urn="urn:adsk.eagle:package:35450579/2" type="model" library_version="3">
+<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt;</description>
+<packageinstances>
+<packageinstance name="SOT23-5"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_5.2MM" urn="urn:adsk.eagle:package:35450571/3" type="model" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 5.2mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/Buttons/SMD-Button.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_5.2MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_PTH_6.0MM" urn="urn:adsk.eagle:package:35450577/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-1000)&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_PTH_6.0MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_PTH_6.0MM_KIT" urn="urn:adsk.eagle:package:35450576/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-1000)&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_PTH_6.0MM_KIT"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_PTH_12MM" urn="urn:adsk.eagle:package:35450575/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 12mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-5050)&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_PTH_12MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT" urn="urn:adsk.eagle:package:35450574/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, Right-angle&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://cdn.sparkfun.com/datasheets/Components/Switches/SW016.JPG"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_4.5MM" urn="urn:adsk.eagle:package:35450573/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 4.5mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://spec_sheets.e-switch.com/specs/P010338.pdf"&gt;Dimensional Drawing&lt;/a&gt;&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_4.5MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_4.6X2.8MM" urn="urn:adsk.eagle:package:35450572/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 4.6 x 2.8mm&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://www.ck-components.com/media/1479/kmr2.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_4.6X2.8MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_6.0X3.5MM" urn="urn:adsk.eagle:package:35450570/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 6.0 x 3.5 mm&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.sparkfun.com/datasheets/Components/1101.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_6.0X3.5MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_6.2MM_TALL" urn="urn:adsk.eagle:package:35450569/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 6.2mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://www.apem.com/files/apem/brochures/ADTS6-ADTSM-KTSC6.pdf"&gt;Datasheet&lt;/a&gt; (ADTSM63NVTR)&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_6.2MM_TALL"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_12MM" urn="urn:adsk.eagle:package:35450568/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, 12mm Square&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://cdn.sparkfun.com/datasheets/Components/Switches/N301102.pdf"&gt;Datasheet&lt;/a&gt;&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_12MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TACTILE_SWITCH_SMD_RIGHT_ANGLE" urn="urn:adsk.eagle:package:35450567/1" type="box" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - SMD, Right-angle&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;</description>
+<packageinstances>
+<packageinstance name="TACTILE_SWITCH_SMD_RIGHT_ANGLE"/>
+</packageinstances>
+</package3d>
+<package3d name="CHIPANTENNA-1206-SHORT" urn="urn:adsk.eagle:package:35450582/1" type="box" library_version="3">
+<packageinstances>
+<packageinstance name="CHIPANTENNA-1206-SHORT"/>
+</packageinstances>
+</package3d>
+<package3d name="CHIPANTENNA-1206" urn="urn:adsk.eagle:package:35450583/1" type="box" library_version="3">
+<packageinstances>
+<packageinstance name="CHIPANTENNA-1206"/>
+</packageinstances>
+</package3d>
+</packages3d>
 <symbols>
-<symbol name="ANTENNA">
+<symbol name="CY8C29666" urn="urn:adsk.eagle:symbol:35450565/1" library_version="3">
+<wire x1="0" y1="48.26" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="53.34" y2="0" width="0.254" layer="94"/>
+<wire x1="53.34" y1="0" x2="53.34" y2="53.34" width="0.254" layer="94"/>
+<wire x1="53.34" y1="53.34" x2="5.08" y2="53.34" width="0.254" layer="94"/>
+<wire x1="5.08" y1="53.34" x2="0" y2="48.26" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="-2.54" y2="-2.54" width="0.1524" layer="94"/>
+<pin name="CAP1_NC" x="12.7" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="CAP2_NC" x="15.24" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="CLK" x="55.88" y="27.94" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="CMD" x="55.88" y="25.4" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="EN" x="-2.54" y="20.32" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO0" x="38.1" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO2" x="35.56" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO4" x="40.64" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO5" x="55.88" y="35.56" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO12" x="25.4" y="-2.54" visible="pin" length="short" direction="pwr" rot="R90"/>
+<pin name="IO13" x="30.48" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO14" x="22.86" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO15" x="33.02" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO16" x="55.88" y="12.7" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO17" x="55.88" y="17.78" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO18" x="55.88" y="38.1" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO19" x="38.1" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="IO21" x="27.94" y="55.88" visible="pin" length="short" direction="pwr" rot="R270"/>
+<pin name="IO22" x="35.56" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="IO23" x="55.88" y="40.64" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO25" x="15.24" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO26" x="17.78" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO27" x="20.32" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO32" x="-2.54" y="12.7" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO33" x="12.7" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO34" x="-2.54" y="17.78" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO35" x="-2.54" y="15.24" visible="pin" length="short" swaplevel="1"/>
+<pin name="LNA_IN" x="-2.54" y="38.1" visible="pin" length="short" swaplevel="1"/>
+<pin name="SD0" x="55.88" y="30.48" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="SD1" x="55.88" y="33.02" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="SD2" x="55.88" y="20.32" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="SD3" x="55.88" y="22.86" visible="pin" length="short" rot="R180"/>
+<pin name="SENSOR_CAPN" x="-2.54" y="25.4" visible="pin" length="short" direction="pwr" swaplevel="1"/>
+<pin name="SENSOR_CAPP" x="-2.54" y="27.94" visible="pin" length="short" swaplevel="1"/>
+<pin name="SENSOR_VN" x="-2.54" y="22.86" visible="pin" length="short" swaplevel="1"/>
+<pin name="SENSOR_VP" x="-2.54" y="30.48" visible="pin" length="short" swaplevel="1"/>
+<pin name="U0RXD" x="33.02" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="U0TXD" x="30.48" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="VDD3P3_CPU" x="40.64" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="VDD3P3_RTC" x="27.94" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="VDDA" x="-2.54" y="40.64" visible="pin" length="short" swaplevel="1"/>
+<pin name="VDDA3P3_1" x="-2.54" y="35.56" visible="pin" length="short" swaplevel="1"/>
+<pin name="VDDA_2" x="25.4" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="VDDA_3" x="17.78" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="VDDA_3P3" x="-2.54" y="33.02" visible="pin" length="short" swaplevel="1"/>
+<pin name="VDD_SDIO_NC" x="55.88" y="15.24" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="XTAL_N_NC" x="22.86" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="XTAL_P_NC" x="20.32" y="55.88" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="GNDPAD" x="-2.54" y="-2.54" visible="off" length="point" rot="R90"/>
+<text x="25.4" y="29.718" size="2.54" layer="95" font="vector" ratio="12" align="center">&gt;NAME</text>
+<text x="25.4" y="26.162" size="1.27" layer="95" font="vector" ratio="12" align="center">&gt;MANF#</text>
+<text x="0.762" y="0.762" size="1.27" layer="97">GNDPAD</text>
+</symbol>
+<symbol name="SN74LVC2T45DCUR" urn="urn:adsk.eagle:symbol:35450562/1" library_version="3">
+<wire x1="0" y1="12.7" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="20.32" y2="0" width="0.254" layer="94"/>
+<wire x1="20.32" y1="0" x2="20.32" y2="12.7" width="0.254" layer="94"/>
+<wire x1="20.32" y1="12.7" x2="0" y2="12.7" width="0.254" layer="94"/>
+<pin name="A1" x="-2.54" y="7.62" length="short"/>
+<pin name="A2" x="-2.54" y="5.08" length="short"/>
+<pin name="B1" x="22.86" y="7.62" length="short" rot="R180"/>
+<pin name="B2" x="22.86" y="5.08" length="short" rot="R180"/>
+<pin name="DIR" x="22.86" y="2.54" length="short" rot="R180"/>
+<pin name="GND" x="-2.54" y="2.54" length="short"/>
+<pin name="VCCA" x="-2.54" y="10.16" length="short"/>
+<pin name="VCCB" x="22.86" y="10.16" length="short" rot="R180"/>
+<text x="10.16" y="15.24" size="2.54" layer="95" font="vector" ratio="12" align="center">&gt;NAME</text>
+<text x="10.16" y="-1.27" size="1.27" layer="95" font="vector" ratio="12" align="center">&gt;MANF#</text>
+</symbol>
+<symbol name="V-REG-LDO_NO-BP" urn="urn:adsk.eagle:symbol:35450563/1" library_version="3">
+<wire x1="0" y1="0" x2="15.24" y2="0" width="0.4064" layer="94"/>
+<wire x1="15.24" y1="0" x2="15.24" y2="10.16" width="0.4064" layer="94"/>
+<wire x1="15.24" y1="10.16" x2="0" y2="10.16" width="0.4064" layer="94"/>
+<wire x1="0" y1="10.16" x2="0" y2="0" width="0.4064" layer="94"/>
+<pin name="EN" x="-2.54" y="5.08" visible="pin" length="short" direction="in"/>
+<pin name="GND" x="-2.54" y="2.54" visible="pin" length="short" direction="in"/>
+<pin name="IN" x="-2.54" y="7.62" visible="pin" length="short" direction="in"/>
+<pin name="NC" x="17.78" y="2.54" visible="pin" length="short" direction="in" rot="R180"/>
+<pin name="OUT" x="17.78" y="7.62" visible="pin" length="short" direction="pas" rot="R180"/>
+<text x="7.62" y="11.684" size="1.778" layer="95" font="vector" ratio="12" align="center">&gt;NAME</text>
+<text x="7.62" y="-1.27" size="1.27" layer="96" font="vector" align="center">&gt;MANF#</text>
+</symbol>
+<symbol name="SWITCH-MOMENTARY-2" urn="urn:adsk.eagle:symbol:35450561/1" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;</description>
+<circle x="-2.54" y="0" radius="0.127" width="0.4064" layer="94"/>
+<circle x="2.54" y="0" radius="0.127" width="0.4064" layer="94"/>
+<wire x1="1.905" y1="0" x2="2.54" y2="0" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="0" x2="1.905" y2="1.27" width="0.254" layer="94"/>
+<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="2"/>
+<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<text x="0" y="1.524" size="1.778" layer="95" font="vector" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-0.508" size="1.778" layer="96" font="vector" align="top-center">&gt;VALUE</text>
+</symbol>
+<symbol name="ANTENNA" urn="urn:adsk.eagle:symbol:35450566/1" library_version="3">
 <description>&lt;h3&gt;Antenna&lt;/h3&gt;</description>
 <wire x1="0" y1="2.54" x2="0" y2="-2.54" width="0.254" layer="94"/>
 <wire x1="-2.54" y1="5.08" x2="2.54" y2="5.08" width="0.254" layer="94"/>
 <wire x1="0" y1="2.54" x2="2.54" y2="5.08" width="0.254" layer="94"/>
 <wire x1="0" y1="2.54" x2="-2.54" y2="5.08" width="0.254" layer="94"/>
+<pin name="SIGNAL" x="0" y="-5.08" visible="off" length="short" rot="R90"/>
 <text x="0.508" y="0" size="1.778" layer="95" font="vector">&gt;NAME</text>
 <text x="0.508" y="-2.54" size="1.778" layer="96" font="vector">&gt;VALUE</text>
-<pin name="SIGNAL" x="0" y="-5.08" visible="off" length="short" rot="R90"/>
-</symbol>
-<symbol name="CY8C29666">
-<wire x1="-30.48" y1="22.86" x2="-30.48" y2="-25.4" width="0.254" layer="94"/>
-<wire x1="-30.48" y1="-25.4" x2="30.48" y2="-25.4" width="0.254" layer="94"/>
-<wire x1="30.48" y1="-25.4" x2="30.48" y2="25.4" width="0.254" layer="94"/>
-<wire x1="30.48" y1="25.4" x2="-27.94" y2="25.4" width="0.254" layer="94"/>
-<wire x1="-27.94" y1="25.4" x2="-30.48" y2="22.86" width="0.254" layer="94"/>
-<text x="-22.86" y="-20.32" size="1.27" layer="95">&gt;NAME</text>
-<text x="-22.86" y="-22.86" size="1.27" layer="95">&gt;VALUE</text>
-<pin name="VDDA_3" x="-15.24" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="CAP2_NC" x="-17.78" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="CAP1_NC" x="-20.32" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="VDDA" x="-33.02" y="12.7" visible="pin" length="short" swaplevel="1"/>
-<pin name="LNA_IN" x="-33.02" y="10.16" visible="pin" length="short" swaplevel="1"/>
-<pin name="SENSOR_CAPN" x="-33.02" y="-2.54" visible="pin" length="short" direction="pwr" swaplevel="1"/>
-<pin name="IO34" x="-33.02" y="-10.16" visible="pin" length="short" swaplevel="1"/>
-<pin name="VDDA3P3_1" x="-33.02" y="7.62" visible="pin" length="short" swaplevel="1"/>
-<pin name="IO26" x="-2.54" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO27" x="0" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO14" x="2.54" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO12" x="5.08" y="-27.94" visible="pin" length="short" direction="pwr" rot="R90"/>
-<pin name="VDD3P3_RTC" x="7.62" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO13" x="10.16" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO15" x="12.7" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO2" x="15.24" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="SD3" x="33.02" y="0" visible="pin" length="short" rot="R180"/>
-<pin name="IO16" x="33.02" y="-10.16" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="VDD_SDIO_NC" x="33.02" y="-7.62" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="IO5" x="33.02" y="12.7" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="IO18" x="33.02" y="15.24" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="IO23" x="33.02" y="17.78" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="VDD3P3_CPU" x="7.62" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="IO19" x="5.08" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="IO22" x="2.54" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="U0RXD" x="0" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="U0TXD" x="-2.54" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="IO21" x="-5.08" y="27.94" visible="pin" length="short" direction="pwr" rot="R270"/>
-<pin name="VDDA_2" x="-7.62" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="XTAL_N_NC" x="-10.16" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="XTAL_P_NC" x="-12.7" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
-<pin name="CMD" x="33.02" y="2.54" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="VDDA_3P3" x="-33.02" y="5.08" visible="pin" length="short" swaplevel="1"/>
-<pin name="SENSOR_VP" x="-33.02" y="2.54" visible="pin" length="short" swaplevel="1"/>
-<pin name="SENSOR_CAPP" x="-33.02" y="0" visible="pin" length="short" swaplevel="1"/>
-<pin name="EN" x="-33.02" y="-7.62" visible="pin" length="short" swaplevel="1"/>
-<pin name="IO35" x="-33.02" y="-12.7" visible="pin" length="short" swaplevel="1"/>
-<pin name="IO25" x="-5.08" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="CLK" x="33.02" y="5.08" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="SD0" x="33.02" y="7.62" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="SD1" x="33.02" y="10.16" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="SENSOR_VN" x="-33.02" y="-5.08" visible="pin" length="short" swaplevel="1"/>
-<pin name="IO17" x="33.02" y="-5.08" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="SD2" x="33.02" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R180"/>
-<pin name="IO32" x="-33.02" y="-15.24" visible="pin" length="short" swaplevel="1"/>
-<pin name="IO33" x="-7.62" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO0" x="17.78" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-<pin name="IO4" x="20.32" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
-</symbol>
-<symbol name="GNDPAD">
-<wire x1="0" y1="0" x2="-2.54" y2="2.54" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="2.54" x2="-2.54" y2="12.7" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="12.7" x2="2.54" y2="12.7" width="0.254" layer="94"/>
-<wire x1="2.54" y1="12.7" x2="2.54" y2="2.54" width="0.254" layer="94"/>
-<wire x1="2.54" y1="2.54" x2="0" y2="0" width="0.254" layer="94"/>
-<pin name="GNDPAD" x="0" y="-2.54" visible="pin" length="short" direction="pwr" rot="R90"/>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="CHIP-ANTENNA">
-<gates>
-<gate name="G$1" symbol="ANTENNA" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="CHIPANTENNA-1206">
-<connects>
-<connect gate="G$1" pin="SIGNAL" pad="P$1"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="SHORT" package="CHIPANTENNA-1206-SHORT">
-<connects>
-<connect gate="G$1" pin="SIGNAL" pad="P$1"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="ESP32-PICO-D4" prefix="IC">
+<deviceset name="ESP32-PICO-D4" urn="urn:adsk.eagle:component:35450587/2" prefix="IC" library_version="3">
 <gates>
 <gate name="G$1" symbol="CY8C29666" x="0" y="0"/>
-<gate name="G$2" symbol="GNDPAD" x="35.56" y="-27.94"/>
 </gates>
 <devices>
 <device name="" package="QFN48">
@@ -4895,6 +4797,7 @@ Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description
 <connect gate="G$1" pin="CLK" pad="31"/>
 <connect gate="G$1" pin="CMD" pad="30"/>
 <connect gate="G$1" pin="EN" pad="9"/>
+<connect gate="G$1" pin="GNDPAD" pad="EXP"/>
 <connect gate="G$1" pin="IO0" pad="23"/>
 <connect gate="G$1" pin="IO12" pad="18"/>
 <connect gate="G$1" pin="IO13" pad="20"/>
@@ -4938,8 +4841,10 @@ Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description
 <connect gate="G$1" pin="VDD_SDIO_NC" pad="26"/>
 <connect gate="G$1" pin="XTAL_N_NC" pad="44"/>
 <connect gate="G$1" pin="XTAL_P_NC" pad="45"/>
-<connect gate="G$2" pin="GNDPAD" pad="EXP"/>
 </connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450581/1"/>
+</package3dinstances>
 <technologies>
 <technology name=""/>
 </technologies>
@@ -4951,6 +4856,7 @@ Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description
 <connect gate="G$1" pin="CLK" pad="31"/>
 <connect gate="G$1" pin="CMD" pad="30"/>
 <connect gate="G$1" pin="EN" pad="9"/>
+<connect gate="G$1" pin="GNDPAD" pad="EXP"/>
 <connect gate="G$1" pin="IO0" pad="23"/>
 <connect gate="G$1" pin="IO12" pad="18"/>
 <connect gate="G$1" pin="IO13" pad="20"/>
@@ -4994,760 +4900,325 @@ Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description
 <connect gate="G$1" pin="VDD_SDIO_NC" pad="26"/>
 <connect gate="G$1" pin="XTAL_N_NC" pad="44"/>
 <connect gate="G$1" pin="XTAL_P_NC" pad="45"/>
-<connect gate="G$2" pin="GNDPAD" pad="EXP"/>
 </connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450580/2"/>
+</package3dinstances>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
 </devices>
 </deviceset>
-</devicesets>
-</library>
-<library name="SparkFun-LED" urn="urn:adsk.eagle:library:529">
-<description>&lt;h3&gt;SparkFun LEDs&lt;/h3&gt;
-This library contains discrete LEDs for illumination or indication, but no displays.
-&lt;br&gt;
-&lt;br&gt;
-We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
-&lt;br&gt;
-&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
-&lt;br&gt;
-&lt;br&gt;
-&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
-&lt;br&gt;
-&lt;br&gt;
-You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
-<packages>
-<package name="LED_5MM" urn="urn:adsk.eagle:footprint:39305/1" library_version="1">
-<description>&lt;B&gt;LED 5mm PTH&lt;/B&gt;&lt;p&gt;
-5 mm, round
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch: 0.1inch&lt;/li&gt;
-&lt;li&gt;Diameter: 5mm&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED-IR-THRU&lt;/li&gt;</description>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.2032" layer="22"/>
-<wire x1="-1.143" y1="0" x2="0" y2="1.143" width="0.1524" layer="51" curve="-90" cap="flat"/>
-<wire x1="0" y1="-1.143" x2="1.143" y2="0" width="0.1524" layer="51" curve="90" cap="flat"/>
-<wire x1="-1.651" y1="0" x2="0" y2="1.651" width="0.1524" layer="51" curve="-90" cap="flat"/>
-<wire x1="0" y1="-1.651" x2="1.651" y2="0" width="0.1524" layer="51" curve="90" cap="flat"/>
-<wire x1="-2.159" y1="0" x2="0" y2="2.159" width="0.1524" layer="51" curve="-90" cap="flat"/>
-<wire x1="0" y1="-2.159" x2="2.159" y2="0" width="0.1524" layer="51" curve="90" cap="flat"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.254" layer="21" curve="-286.260205" cap="flat"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.2032" layer="51"/>
-<pad name="A" x="-1.27" y="0" drill="0.8128" diameter="1.8796"/>
-<pad name="K" x="1.27" y="0" drill="0.8128" diameter="1.8796"/>
-<text x="0" y="3.3909" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0.0254" y="-3.3909" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<circle x="0" y="0" radius="2.54" width="0.1524" layer="21"/>
-</package>
-<package name="LED_3MM" urn="urn:adsk.eagle:footprint:39306/1" library_version="1">
-<description>&lt;h3&gt;LED 3MM PTH&lt;/h3&gt;
-
-3 mm, round.
-
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch: 0.1inch&lt;/li&gt;
-&lt;li&gt;Diameter: 3mm&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED&lt;/li&gt;&lt;/ul&gt;</description>
-<wire x1="1.5748" y1="-1.27" x2="1.5748" y2="1.27" width="0.254" layer="51"/>
-<wire x1="0" y1="2.032" x2="1.561" y2="1.3009" width="0.254" layer="22" curve="-50.193108" cap="flat"/>
-<wire x1="-1.7929" y1="0.9562" x2="0" y2="2.032" width="0.254" layer="22" curve="-61.926949" cap="flat"/>
-<wire x1="0" y1="-2.032" x2="1.5512" y2="-1.3126" width="0.254" layer="22" curve="49.763022" cap="flat"/>
-<wire x1="-1.7643" y1="-1.0082" x2="0" y2="-2.032" width="0.254" layer="22" curve="60.255215" cap="flat"/>
-<wire x1="-2.032" y1="0" x2="-1.7891" y2="0.9634" width="0.254" layer="51" curve="-28.301701" cap="flat"/>
-<wire x1="-2.032" y1="0" x2="-1.7306" y2="-1.065" width="0.254" layer="51" curve="31.60822" cap="flat"/>
-<wire x1="1.5748" y1="1.2954" x2="1.5748" y2="0.7874" width="0.254" layer="22"/>
-<wire x1="1.5748" y1="-1.2954" x2="1.5748" y2="-0.8382" width="0.254" layer="22"/>
-<wire x1="0" y1="2.032" x2="1.561" y2="1.3009" width="0.254" layer="21" curve="-50.193108" cap="flat"/>
-<wire x1="-1.7929" y1="0.9562" x2="0" y2="2.032" width="0.254" layer="21" curve="-61.926949" cap="flat"/>
-<wire x1="0" y1="-2.032" x2="1.5512" y2="-1.3126" width="0.254" layer="21" curve="49.763022" cap="flat"/>
-<wire x1="-1.7643" y1="-1.0082" x2="0" y2="-2.032" width="0.254" layer="21" curve="60.255215" cap="flat"/>
-<wire x1="1.5748" y1="1.2954" x2="1.5748" y2="0.7874" width="0.254" layer="21"/>
-<wire x1="1.5748" y1="-1.2954" x2="1.5748" y2="-0.8382" width="0.254" layer="21"/>
-<pad name="A" x="-1.27" y="0" drill="0.8128" diameter="1.8796"/>
-<pad name="K" x="1.27" y="0" drill="0.8128" diameter="1.8796"/>
-<text x="0" y="2.286" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-</package>
-<package name="LED-1206" urn="urn:adsk.eagle:footprint:39304/1" library_version="1">
-<description>&lt;h3&gt;LED 1206 SMT&lt;/h3&gt;
-
-1206, surface mount. 
-
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch: &lt;/li&gt;
-&lt;li&gt;Area: 0.125" x 0.06"&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED&lt;/li&gt;&lt;/ul&gt;</description>
-<wire x1="2.4" y1="0.6825" x2="2.4" y2="-0.6825" width="0.2032" layer="21"/>
-<wire x1="0.65375" y1="0.6825" x2="0.65375" y2="-0.6825" width="0.2032" layer="51"/>
-<wire x1="0.635" y1="0" x2="0.15875" y2="0.47625" width="0.2032" layer="51"/>
-<wire x1="0.635" y1="0" x2="0.15875" y2="-0.47625" width="0.2032" layer="51"/>
-<smd name="A" x="-1.5" y="0" dx="1.2" dy="1.4" layer="1"/>
-<smd name="C" x="1.5" y="0" dx="1.2" dy="1.4" layer="1"/>
-<text x="0" y="0.9525" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.9525" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-</package>
-<package name="LED-0603" urn="urn:adsk.eagle:footprint:39307/1" library_version="1">
-<description>&lt;B&gt;LED 0603 SMT&lt;/B&gt;&lt;p&gt;
-0603, surface mount.
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch:0.075inch &lt;/li&gt;
-&lt;li&gt;Area: 0.06" x 0.03"&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED - BLUE&lt;/li&gt;</description>
-<smd name="C" x="0.877" y="0" dx="1" dy="1" layer="1" roundness="30" rot="R270"/>
-<smd name="A" x="-0.877" y="0" dx="1" dy="1" layer="1" roundness="30" rot="R270"/>
-<text x="0" y="0.635" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-0.635" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<wire x1="1.5875" y1="0.47625" x2="1.5875" y2="-0.47625" width="0.127" layer="21"/>
-<wire x1="0.15875" y1="0.47625" x2="0.15875" y2="0" width="0.127" layer="51"/>
-<wire x1="0.15875" y1="0" x2="0.15875" y2="-0.47625" width="0.127" layer="51"/>
-<wire x1="0.15875" y1="0" x2="-0.15875" y2="0.3175" width="0.127" layer="51"/>
-<wire x1="0.15875" y1="0" x2="-0.15875" y2="-0.3175" width="0.127" layer="51"/>
-</package>
-<package name="LED_10MM" urn="urn:adsk.eagle:footprint:39308/1" library_version="1">
-<description>&lt;B&gt;LED 10mm PTH&lt;/B&gt;&lt;p&gt;
-10 mm, round
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch: 0.2inch&lt;/li&gt;
-&lt;li&gt;Diameter: 10mm&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED&lt;/li&gt;</description>
-<wire x1="-5" y1="-2" x2="-5" y2="2" width="0.2032" layer="21" curve="316.862624"/>
-<wire x1="-5" y1="2" x2="-5" y2="-2" width="0.2032" layer="21"/>
-<wire x1="-5" y1="2" x2="-5" y2="-2" width="0.2032" layer="22"/>
-<wire x1="-5" y1="2" x2="-5" y2="-2" width="0.2032" layer="51"/>
-<pad name="A" x="2.54" y="0" drill="2.4" diameter="3.7"/>
-<pad name="C" x="-2.54" y="0" drill="2.4" diameter="3.7"/>
-<text x="2.159" y="2.54" size="1.016" layer="51" ratio="15">L</text>
-<text x="-2.921" y="2.54" size="1.016" layer="51" ratio="15">S</text>
-<text x="0" y="5.715" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-5.715" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-</package>
-<package name="FKIT-LED-1206" urn="urn:adsk.eagle:footprint:39309/1" library_version="1">
-<description>&lt;B&gt;LED 1206 SMT&lt;/B&gt;&lt;p&gt;
-1206, surface mount
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Area: 0.125"x 0.06" &lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED&lt;/li&gt;</description>
-<wire x1="1.55" y1="-0.75" x2="-1.55" y2="-0.75" width="0.1016" layer="51"/>
-<wire x1="-1.55" y1="-0.75" x2="-1.55" y2="0.75" width="0.1016" layer="51"/>
-<wire x1="-1.55" y1="0.75" x2="1.55" y2="0.75" width="0.1016" layer="51"/>
-<wire x1="1.55" y1="0.75" x2="1.55" y2="-0.75" width="0.1016" layer="51"/>
-<wire x1="-0.55" y1="0.5" x2="-0.55" y2="-0.5" width="0.1016" layer="51" curve="84.547378"/>
-<wire x1="0.55" y1="-0.5" x2="0.55" y2="0.5" width="0.1016" layer="51" curve="84.547378"/>
-<wire x1="2.54" y1="0.9525" x2="2.54" y2="-0.9525" width="0.2032" layer="21"/>
-<wire x1="0.3175" y1="0.635" x2="0.3175" y2="0" width="0.2032" layer="51"/>
-<wire x1="0.3175" y1="0" x2="0.3175" y2="-0.635" width="0.2032" layer="51"/>
-<wire x1="0.3175" y1="0" x2="0" y2="0.3175" width="0.2032" layer="51"/>
-<wire x1="0.3175" y1="0" x2="0" y2="-0.3175" width="0.2032" layer="51"/>
-<smd name="A" x="-1.422" y="0" dx="1.6" dy="1.803" layer="1"/>
-<smd name="C" x="1.422" y="0" dx="1.6" dy="1.803" layer="1"/>
-<text x="0" y="1.11125" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.11125" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<rectangle x1="0.45" y1="-0.7" x2="0.8" y2="-0.45" layer="51"/>
-<rectangle x1="0.8" y1="-0.7" x2="0.9" y2="0.5" layer="51"/>
-<rectangle x1="0.8" y1="0.55" x2="0.9" y2="0.7" layer="51"/>
-<rectangle x1="-0.9" y1="-0.7" x2="-0.8" y2="0.5" layer="51"/>
-<rectangle x1="-0.9" y1="0.55" x2="-0.8" y2="0.7" layer="51"/>
-</package>
-<package name="LED_3MM-NS" urn="urn:adsk.eagle:footprint:39310/1" library_version="1">
-<description>&lt;h3&gt;LED 3MM PTH- No Silk&lt;/h3&gt;
-
-3 mm, round, no silk outline of package
-
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch: 0.1inch&lt;/li&gt;
-&lt;li&gt;Diameter: 3mm&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED&lt;/li&gt;&lt;/ul&gt;</description>
-<wire x1="1.5748" y1="-1.27" x2="1.5748" y2="1.27" width="0.254" layer="51"/>
-<wire x1="0" y1="2.032" x2="1.561" y2="1.3009" width="0.254" layer="51" curve="-50.193108" cap="flat"/>
-<wire x1="-1.7929" y1="0.9562" x2="0" y2="2.032" width="0.254" layer="51" curve="-61.926949" cap="flat"/>
-<wire x1="0" y1="-2.032" x2="1.5512" y2="-1.3126" width="0.254" layer="51" curve="49.763022" cap="flat"/>
-<wire x1="-1.7643" y1="-1.0082" x2="0" y2="-2.032" width="0.254" layer="51" curve="60.255215" cap="flat"/>
-<wire x1="-2.032" y1="0" x2="-1.7891" y2="0.9634" width="0.254" layer="51" curve="-28.301701" cap="flat"/>
-<wire x1="-2.032" y1="0" x2="-1.7306" y2="-1.065" width="0.254" layer="51" curve="31.60822" cap="flat"/>
-<wire x1="1.5748" y1="1.2954" x2="1.5748" y2="0.7874" width="0.254" layer="51"/>
-<wire x1="1.5748" y1="-1.2954" x2="1.5748" y2="-0.8382" width="0.254" layer="51"/>
-<wire x1="1.8923" y1="1.2954" x2="1.8923" y2="0.7874" width="0.254" layer="21"/>
-<wire x1="1.8923" y1="-1.2954" x2="1.8923" y2="-0.8382" width="0.254" layer="21"/>
-<pad name="A" x="-1.27" y="0" drill="0.8128"/>
-<pad name="K" x="1.27" y="0" drill="0.8128"/>
-<text x="0" y="2.286" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-</package>
-<package name="LED_5MM-KIT" urn="urn:adsk.eagle:footprint:39311/1" library_version="1">
-<description>&lt;h3&gt;LED 5mm KIT PTH&lt;/h3&gt;
-&lt;p&gt;
-&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;
-
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Pin pitch: 0.1inch&lt;/li&gt;
-&lt;li&gt;Diameter: 5mm&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example Device:
-&lt;ul&gt;&lt;li&gt;LED&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;</description>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.2032" layer="22"/>
-<wire x1="-1.143" y1="0" x2="0" y2="1.143" width="0.1524" layer="51" curve="-90" cap="flat"/>
-<wire x1="0" y1="-1.143" x2="1.143" y2="0" width="0.1524" layer="51" curve="90" cap="flat"/>
-<wire x1="-1.651" y1="0" x2="0" y2="1.651" width="0.1524" layer="51" curve="-90" cap="flat"/>
-<wire x1="0" y1="-1.651" x2="1.651" y2="0" width="0.1524" layer="51" curve="90" cap="flat"/>
-<wire x1="-2.159" y1="0" x2="0" y2="2.159" width="0.1524" layer="51" curve="-90" cap="flat"/>
-<wire x1="0" y1="-2.159" x2="2.159" y2="0" width="0.1524" layer="51" curve="90" cap="flat"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.254" layer="21" curve="-286.260205" cap="flat"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.2032" layer="51"/>
-<pad name="A" x="-1.27" y="0" drill="0.8128" diameter="1.8796" stop="no"/>
-<pad name="K" x="1.27" y="0" drill="0.8128" diameter="1.8796" stop="no"/>
-<text x="0" y="3.3909" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0.0254" y="-3.3909" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-<polygon width="0.127" layer="30">
-<vertex x="-1.2675" y="-0.9525" curve="-90"/>
-<vertex x="-2.2224" y="-0.0228" curve="-90.011749"/>
-<vertex x="-1.27" y="0.9526" curve="-90"/>
-<vertex x="-0.32" y="-0.0254" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-1.27" y="-0.4445" curve="-90.012891"/>
-<vertex x="-1.7145" y="-0.0203" curve="-90"/>
-<vertex x="-1.27" y="0.447" curve="-90"/>
-<vertex x="-0.8281" y="-0.0101" curve="-90.012967"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="1.2725" y="-0.9525" curve="-90"/>
-<vertex x="0.3176" y="-0.0228" curve="-90.011749"/>
-<vertex x="1.27" y="0.9526" curve="-90"/>
-<vertex x="2.22" y="-0.0254" curve="-90.024193"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="1.27" y="-0.4445" curve="-90.012891"/>
-<vertex x="0.8255" y="-0.0203" curve="-90"/>
-<vertex x="1.27" y="0.447" curve="-90"/>
-<vertex x="1.7119" y="-0.0101" curve="-90.012967"/>
-</polygon>
-<circle x="0" y="0" radius="2.54" width="0.1524" layer="21"/>
-</package>
-<package name="LED-1206-BOTTOM" urn="urn:adsk.eagle:footprint:39312/1" library_version="1">
-<description>&lt;h3&gt;LED 1206 SMT&lt;/h3&gt;
-
-1206, surface mount. 
-
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count: 2&lt;/li&gt;
-&lt;li&gt;Area: 0.125" x 0.06"&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;LED&lt;/li&gt;&lt;/ul&gt;</description>
-<wire x1="-2" y1="0.4" x2="-2" y2="-0.4" width="0.127" layer="49"/>
-<wire x1="-2.4" y1="0" x2="-1.6" y2="0" width="0.127" layer="49"/>
-<wire x1="1.6" y1="0" x2="2.4" y2="0" width="0.127" layer="49"/>
-<wire x1="-1.27" y1="0" x2="-0.381" y2="0" width="0.127" layer="49"/>
-<wire x1="-0.381" y1="0" x2="-0.381" y2="0.635" width="0.127" layer="49"/>
-<wire x1="-0.381" y1="0.635" x2="0.254" y2="0" width="0.127" layer="49"/>
-<wire x1="0.254" y1="0" x2="-0.381" y2="-0.635" width="0.127" layer="49"/>
-<wire x1="-0.381" y1="-0.635" x2="-0.381" y2="0" width="0.127" layer="49"/>
-<wire x1="0.254" y1="0" x2="0.254" y2="0.635" width="0.127" layer="49"/>
-<wire x1="0.254" y1="0" x2="0.254" y2="-0.635" width="0.127" layer="49"/>
-<wire x1="0.254" y1="0" x2="1.27" y2="0" width="0.127" layer="49"/>
-<wire x1="2.7686" y1="1.016" x2="2.7686" y2="-1.016" width="0.127" layer="21"/>
-<wire x1="2.7686" y1="1.016" x2="2.7686" y2="-1.016" width="0.127" layer="22"/>
-<rectangle x1="-0.75" y1="-0.75" x2="0.75" y2="0.75" layer="51"/>
-<smd name="A" x="-1.8" y="0" dx="1.5" dy="1.6" layer="1"/>
-<smd name="C" x="1.8" y="0" dx="1.5" dy="1.6" layer="1"/>
-<hole x="0" y="0" drill="2.3"/>
-<polygon width="0" layer="51">
-<vertex x="1.1" y="-0.5"/>
-<vertex x="1.1" y="0.5"/>
-<vertex x="1.6" y="0.5"/>
-<vertex x="1.6" y="0.25" curve="90"/>
-<vertex x="1.4" y="0.05"/>
-<vertex x="1.4" y="-0.05" curve="90"/>
-<vertex x="1.6" y="-0.25"/>
-<vertex x="1.6" y="-0.5"/>
-</polygon>
-<polygon width="0" layer="51">
-<vertex x="-1.1" y="0.5"/>
-<vertex x="-1.1" y="-0.5"/>
-<vertex x="-1.6" y="-0.5"/>
-<vertex x="-1.6" y="-0.25" curve="90"/>
-<vertex x="-1.4" y="-0.05"/>
-<vertex x="-1.4" y="0.05" curve="90"/>
-<vertex x="-1.6" y="0.25"/>
-<vertex x="-1.6" y="0.5"/>
-</polygon>
-<text x="0" y="1.27" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-1.27" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
-</package>
-</packages>
-<packages3d>
-<package3d name="LED_5MM" urn="urn:adsk.eagle:package:39353/1" type="box" library_version="1">
-<description>LED 5mm PTH
-5 mm, round
-Specifications:
-Pin count: 2
-Pin pitch: 0.1inch
-Diameter: 5mm
-
-Example device(s):
-LED-IR-THRU</description>
-<packageinstances>
-<packageinstance name="LED_5MM"/>
-</packageinstances>
-</package3d>
-<package3d name="LED_3MM" urn="urn:adsk.eagle:package:39361/1" type="box" library_version="1">
-<description>LED 3MM PTH
-
-3 mm, round.
-
-Specifications:
-Pin count: 2
-Pin pitch: 0.1inch
-Diameter: 3mm
-
-Example device(s):
-LED</description>
-<packageinstances>
-<packageinstance name="LED_3MM"/>
-</packageinstances>
-</package3d>
-<package3d name="LED-1206" urn="urn:adsk.eagle:package:39352/1" type="box" library_version="1">
-<description>LED 1206 SMT
-
-1206, surface mount. 
-
-Specifications:
-Pin count: 2
-Pin pitch: 
-Area: 0.125" x 0.06"
-
-Example device(s):
-LED</description>
-<packageinstances>
-<packageinstance name="LED-1206"/>
-</packageinstances>
-</package3d>
-<package3d name="LED-0603" urn="urn:adsk.eagle:package:39354/1" type="box" library_version="1">
-<description>LED 0603 SMT
-0603, surface mount.
-Specifications:
-Pin count: 2
-Pin pitch:0.075inch 
-Area: 0.06" x 0.03"
-
-Example device(s):
-LED - BLUE</description>
-<packageinstances>
-<packageinstance name="LED-0603"/>
-</packageinstances>
-</package3d>
-<package3d name="LED_10MM" urn="urn:adsk.eagle:package:39351/1" type="box" library_version="1">
-<description>LED 10mm PTH
-10 mm, round
-Specifications:
-Pin count: 2
-Pin pitch: 0.2inch
-Diameter: 10mm
-
-Example device(s):
-LED</description>
-<packageinstances>
-<packageinstance name="LED_10MM"/>
-</packageinstances>
-</package3d>
-<package3d name="FKIT-LED-1206" urn="urn:adsk.eagle:package:39355/1" type="box" library_version="1">
-<description>LED 1206 SMT
-1206, surface mount
-Specifications:
-Pin count: 2
-Area: 0.125"x 0.06" 
-
-Example device(s):
-LED</description>
-<packageinstances>
-<packageinstance name="FKIT-LED-1206"/>
-</packageinstances>
-</package3d>
-<package3d name="LED_3MM-NS" urn="urn:adsk.eagle:package:39356/1" type="box" library_version="1">
-<description>LED 3MM PTH- No Silk
-
-3 mm, round, no silk outline of package
-
-Specifications:
-Pin count: 2
-Pin pitch: 0.1inch
-Diameter: 3mm
-
-Example device(s):
-LED</description>
-<packageinstances>
-<packageinstance name="LED_3MM-NS"/>
-</packageinstances>
-</package3d>
-<package3d name="LED_5MM-KIT" urn="urn:adsk.eagle:package:39357/1" type="box" library_version="1">
-<description>LED 5mm KIT PTH
-
-Warning: This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.
-
-Specifications:
-Pin count: 2
-Pin pitch: 0.1inch
-Diameter: 5mm
-
-Example Device:
-LED
-</description>
-<packageinstances>
-<packageinstance name="LED_5MM-KIT"/>
-</packageinstances>
-</package3d>
-<package3d name="LED-1206-BOTTOM" urn="urn:adsk.eagle:package:39358/1" type="box" library_version="1">
-<description>LED 1206 SMT
-
-1206, surface mount. 
-
-Specifications:
-Pin count: 2
-Area: 0.125" x 0.06"
-
-Example device(s):
-LED</description>
-<packageinstances>
-<packageinstance name="LED-1206-BOTTOM"/>
-</packageinstances>
-</package3d>
-</packages3d>
-<symbols>
-<symbol name="LED" urn="urn:adsk.eagle:symbol:39303/1" library_version="1">
-<description>&lt;h3&gt;LED&lt;/h3&gt;
-&lt;p&gt;&lt;/p&gt;</description>
-<wire x1="1.27" y1="0" x2="0" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="-1.27" y2="0" width="0.254" layer="94"/>
-<wire x1="1.27" y1="-2.54" x2="0" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="-1.27" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="1.27" y1="0" x2="-1.27" y2="0" width="0.254" layer="94"/>
-<wire x1="-2.032" y1="-0.762" x2="-3.429" y2="-2.159" width="0.1524" layer="94"/>
-<wire x1="-1.905" y1="-1.905" x2="-3.302" y2="-3.302" width="0.1524" layer="94"/>
-<text x="-3.429" y="-4.572" size="1.778" layer="95" font="vector" rot="R90">&gt;NAME</text>
-<text x="1.905" y="-4.572" size="1.778" layer="96" font="vector" rot="R90" align="top-left">&gt;VALUE</text>
-<pin name="C" x="0" y="-5.08" visible="off" length="short" direction="pas" rot="R90"/>
-<pin name="A" x="0" y="2.54" visible="off" length="short" direction="pas" rot="R270"/>
-<polygon width="0.1524" layer="94">
-<vertex x="-3.429" y="-2.159"/>
-<vertex x="-3.048" y="-1.27"/>
-<vertex x="-2.54" y="-1.778"/>
-</polygon>
-<polygon width="0.1524" layer="94">
-<vertex x="-3.302" y="-3.302"/>
-<vertex x="-2.921" y="-2.413"/>
-<vertex x="-2.413" y="-2.921"/>
-</polygon>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="LED" urn="urn:adsk.eagle:component:39399/1" prefix="D" uservalue="yes" library_version="1">
-<description>&lt;b&gt;LED (Generic)&lt;/b&gt;
-&lt;p&gt;Standard schematic elements and footprints for 5mm, 3mm, 1206, and 0603 sized LEDs. Generic LEDs with no color specified.&lt;/p&gt;</description>
+<deviceset name="SN74LVC2T45DCUR" urn="urn:adsk.eagle:component:35450585/2" library_version="3">
 <gates>
-<gate name="G$1" symbol="LED" x="0" y="0"/>
+<gate name="G$1" symbol="SN74LVC2T45DCUR" x="-10.16" y="-2.54"/>
 </gates>
 <devices>
-<device name="5MM" package="LED_5MM">
+<device name="" package="SOP50P310X90-8N">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="K"/>
+<connect gate="G$1" pin="A1" pad="2"/>
+<connect gate="G$1" pin="A2" pad="3"/>
+<connect gate="G$1" pin="B1" pad="7"/>
+<connect gate="G$1" pin="B2" pad="6"/>
+<connect gate="G$1" pin="DIR" pad="5"/>
+<connect gate="G$1" pin="GND" pad="4"/>
+<connect gate="G$1" pin="VCCA" pad="1"/>
+<connect gate="G$1" pin="VCCB" pad="8"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39353/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450578/3"/>
 </package3dinstances>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="3MM" package="LED_3MM">
+</devices>
+</deviceset>
+<deviceset name="V_REG_AP2112" urn="urn:adsk.eagle:component:35450586/2" prefix="U" library_version="3">
+<description>&lt;h3&gt;AP2112 - 600mA CMOS LDO Regulator w/ Enable&lt;/h3&gt;
+&lt;p&gt;The AP2112 is CMOS process low dropout linear regulator with enable function, the regulator delivers a guaranteed 600mA (min.) continuous load current.&lt;/p&gt;
+&lt;p&gt;Features&lt;br&gt;
+&lt;ul&gt;
+&lt;li&gt;Output Voltage Accuracy: ±1.5% &lt;/li&gt;
+&lt;li&gt;Output Current: 600mA (Min.) &lt;/li&gt;
+&lt;li&gt;Foldback Short Current Protection: 50mA &lt;/li&gt;
+&lt;li&gt;Enable Function to Turn ON/OFF VOUT&lt;/li&gt;
+&lt;li&gt;Low Dropout Voltage (3.3V): 250mV (Typ.) @IOUT=600mA &lt;/li&gt;
+&lt;li&gt;Excellent Load Regulation: 0.2%/A (Typ.) &lt;/li&gt;
+&lt;li&gt;Excellent Line Regulation: 0.02%/V (Typ.) &lt;/li&gt;
+&lt;li&gt;Low Quiescent Current: 55μA (Typ.)&lt;/li&gt;
+&lt;li&gt;Low Standby Current: 0.01μA (Typ.)&lt;/li&gt;
+&lt;li&gt;Low Output Noise: 50μVRMS &lt;/li&gt;
+&lt;li&gt;PSRR: 100Hz -65dB, 1kHz -65dB &lt;/li&gt;
+&lt;li&gt; OTSD Protection &lt;/li&gt;
+&lt;li&gt;Stable  with  1.0μF Flexible Cap: Ceramic, Tantalum and Aluminum Electrolytic &lt;/li&gt;
+&lt;li&gt;Operation Temperature Range: -40°C to 85°C &lt;/li&gt;
+&lt;li&gt;ESD: MM 400V, HBM 4000V&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="V-REG-LDO_NO-BP" x="0" y="0"/>
+</gates>
+<devices>
+<device name="K-3.3V" package="SOT23-5">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="K"/>
+<connect gate="G$1" pin="EN" pad="3"/>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="NC" pad="4"/>
+<connect gate="G$1" pin="OUT" pad="5"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39361/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450579/2"/>
 </package3dinstances>
 <technologies>
 <technology name="">
-<attribute name="PROD_ID" value="DIO-08794" constant="no"/>
+<attribute name="PROD_ID" value="VREG-12457"/>
+<attribute name="VALUE" value="3.3V"/>
 </technology>
-</technologies>
-</device>
-<device name="1206" package="LED-1206">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39352/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="0603" package="LED-0603">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39354/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="10MM" package="LED_10MM">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39351/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-FKIT-1206" package="FKIT-LED-1206">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39355/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="-3MM-NO_SILK" package="LED_3MM-NS">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="K"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39356/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="5MM-KIT" package="LED_5MM-KIT">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="K"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39357/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="1206-BOTTOM" package="LED-1206-BOTTOM">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:39358/1"/>
-</package3dinstances>
-<technologies>
-<technology name=""/>
 </technologies>
 </device>
 </devices>
 </deviceset>
-</devicesets>
-</library>
-<library name="Seeed-Capacitor" urn="urn:adsk.eagle:library:464">
-<packages>
-<package name="C0402" urn="urn:adsk.eagle:footprint:32368/1" library_version="1">
-<description>&lt;b&gt;0402&lt;b&gt;&lt;p&gt;</description>
-<smd name="1" x="0" y="0.4625" dx="0.5" dy="0.5" layer="1" roundness="50" rot="R270"/>
-<smd name="2" x="0" y="-0.4625" dx="0.5" dy="0.5" layer="1" roundness="50" rot="R270"/>
-<text x="0.635" y="1.27" size="0.889" layer="25" ratio="11" rot="R270">&gt;NAME</text>
-<text x="-1.524" y="1.397" size="0.635" layer="27" font="vector" ratio="10" rot="R270">&gt;VALUE</text>
-<polygon width="0.0254" layer="51">
-<vertex x="0.254" y="0.508"/>
-<vertex x="0.254" y="-0.508"/>
-<vertex x="-0.254" y="-0.508"/>
-<vertex x="-0.254" y="0.508"/>
-</polygon>
-<wire x1="0.3945" y1="-0.712" x2="0.2675" y2="-0.839" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.2675" y1="-0.839" x2="-0.2675" y2="-0.839" width="0.0762" layer="21"/>
-<wire x1="-0.2675" y1="-0.839" x2="-0.3945" y2="-0.712" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.3945" y1="-0.712" x2="-0.3945" y2="0.712" width="0.0762" layer="21"/>
-<wire x1="-0.3945" y1="0.712" x2="-0.2675" y2="0.839" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.2675" y1="0.839" x2="0.2675" y2="0.839" width="0.0762" layer="21"/>
-<wire x1="0.2675" y1="0.839" x2="0.3945" y2="0.712" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.3945" y1="0.712" x2="0.3945" y2="-0.712" width="0.0762" layer="21"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="C0402" urn="urn:adsk.eagle:package:32379/1" type="box" library_version="1">
-<description>0402</description>
-<packageinstances>
-<packageinstance name="C0402"/>
-</packageinstances>
-</package3d>
-</packages3d>
-<symbols>
-<symbol name="C" urn="urn:adsk.eagle:symbol:32365/1" library_version="1">
-<wire x1="-0.635" y1="-1.016" x2="-0.635" y2="0" width="0.254" layer="94"/>
-<wire x1="-0.635" y1="0" x2="-0.635" y2="1.016" width="0.254" layer="94"/>
-<wire x1="0.635" y1="1.016" x2="0.635" y2="0" width="0.254" layer="94"/>
-<wire x1="0.635" y1="0" x2="0.635" y2="-1.016" width="0.254" layer="94"/>
-<wire x1="-1.27" y1="0" x2="-0.635" y2="0" width="0.1524" layer="94"/>
-<wire x1="0.635" y1="0" x2="1.27" y2="0" width="0.1524" layer="94"/>
-<text x="-3.81" y="1.27" size="1.27" layer="95" ratio="10">&gt;NAME</text>
-<text x="-3.81" y="-2.54" size="1.27" layer="96" ratio="10">&gt;VALUE</text>
-<pin name="1" x="-3.81" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
-<pin name="2" x="3.81" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="CERAMIC-1.5PF-50V-0.1PF-NPO(0402)" urn="urn:adsk.eagle:component:32419/1" prefix="C" uservalue="yes" library_version="1">
-<description>302010023</description>
+<deviceset name="MOMENTARY-SWITCH-SPST" urn="urn:adsk.eagle:component:35450584/2" prefix="S" library_version="3">
+<description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST&lt;/h3&gt;
+&lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
+&lt;h4&gt;Variants&lt;/h4&gt;
+&lt;h5&gt;PTH-12MM - 12mm square, through-hole&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/9190"&gt;Momentary Pushbutton Switch - 12mm Square&lt;/a&gt; (COM-09190)&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;PTH-6.0MM, PTH-6.0MM-KIT - 6.0mm square, through-hole&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/97"&gt;Mini Pushbutton Switch&lt;/a&gt; (COM-00097)&lt;/li&gt;
+&lt;li&gt;KIT package intended for soldering kit's - only one side of pads' copper is exposed.&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;PTH-RIGHT-ANGLE-KIT - Right-angle, through-hole&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/10791"&gt;Right Angle Tactile Button&lt;/a&gt; - Used on &lt;a href="https://www.sparkfun.com/products/11734"&gt;
+SparkFun BigTime Watch Kit&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;SMD-12MM - 12mm square, surface-mount&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/12993"&gt;Tactile Button - SMD (12mm)&lt;/a&gt; (COM-12993)&lt;/li&gt;
+&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/11888"&gt;SparkFun PicoBoard&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;SMD-4.5MM - 4.5mm Square Trackball Switch&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/13169"&gt;SparkFun Blackberry Trackballer Breakout&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;SMD-4.6MMX2.8MM -  4.60mm x 2.80mm, surface mount&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/13664"&gt;SparkFun SAMD21 Mini Breakout&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;SMD-5.2MM, SMD-5.2-REDUNDANT - 5.2mm square, surface-mount&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/8720"&gt;Mini Pushbutton Switch - SMD&lt;/a&gt; (COM-08720)&lt;/li&gt;
+&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/11114"&gt;Arduino Pro Mini&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;REDUNDANT package connects both switch circuits together&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;SMD-6.0X3.5MM - 6.0 x 3.5mm, surface mount&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/8229"&gt;Momentary Reset Switch SMD&lt;/a&gt; (COM-08229)&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;SMD-6.2MM-TALL - 6.2mm square, surface mount&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/12992"&gt;Tactile Button - SMD (6mm)&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/12651"&gt;SparkFun Digital Sandbox&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+&lt;h5&gt;SMD-RIGHT-ANGLE - Right-angle, surface mount&lt;/h5&gt;
+&lt;ul&gt;&lt;li&gt;Used on &lt;a href="https://www.sparkfun.com/products/13036"&gt;SparkFun Block for Intel® Edison - Arduino&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</description>
 <gates>
-<gate name="G$1" symbol="C" x="0" y="0"/>
+<gate name="G$1" symbol="SWITCH-MOMENTARY-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="C0402">
+<device name="-PTH-6.0MM" package="TACTILE_SWITCH_PTH_6.0MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450577/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value=" SWCH-08441"/>
+<attribute name="SF_SKU" value="COM-00097"/>
+</technology>
+</technologies>
+</device>
+<device name="-PTH-6.0MM-KIT" package="TACTILE_SWITCH_PTH_6.0MM_KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450576/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-08441"/>
+<attribute name="SF_SKU" value="COM-00097 "/>
+</technology>
+</technologies>
+</device>
+<device name="-PTH-12MM" package="TACTILE_SWITCH_PTH_12MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450575/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-09185"/>
+<attribute name="SF_SKU" value="COM-09190"/>
+</technology>
+</technologies>
+</device>
+<device name="-PTH-RIGHT-ANGLE-KIT" package="TACTILE_SWITCH_PTH_RIGHT_ANGLE_KIT">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:32379/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450574/1"/>
 </package3dinstances>
 <technologies>
 <technology name="">
-<attribute name="MPN" value="CC0402BRNPO9BN1R5"/>
-<attribute name="VALUE" value="1.5PF" constant="no"/>
+<attribute name="PROD_ID" value="CONN-10672"/>
+<attribute name="SF_SKU" value="COM-10791"/>
 </technology>
 </technologies>
 </device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
-<library name="Seeed-Inductor" urn="urn:adsk.eagle:library:471">
-<packages>
-<package name="L0402" urn="urn:adsk.eagle:footprint:32712/1" library_version="1">
-<smd name="1" x="-0.4625" y="0" dx="0.5" dy="0.5" layer="1" roundness="50"/>
-<smd name="2" x="0.4625" y="0" dx="0.5" dy="0.5" layer="1" roundness="50"/>
-<text x="-1.27" y="0.635" size="0.889" layer="25" ratio="11">&gt;NAME</text>
-<text x="-1.27" y="-1.524" size="0.889" layer="27" font="vector" ratio="11">&gt;VALUE</text>
-<wire x1="0.712" y1="0.3945" x2="0.839" y2="0.2675" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.839" y1="0.2675" x2="0.839" y2="-0.2675" width="0.0762" layer="21"/>
-<wire x1="0.839" y1="-0.2675" x2="0.712" y2="-0.3945" width="0.0762" layer="21" curve="-90"/>
-<wire x1="0.712" y1="-0.3945" x2="-0.712" y2="-0.3945" width="0.0762" layer="21"/>
-<wire x1="-0.712" y1="-0.3945" x2="-0.839" y2="-0.2675" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.839" y1="-0.2675" x2="-0.839" y2="0.2675" width="0.0762" layer="21"/>
-<wire x1="-0.839" y1="0.2675" x2="-0.712" y2="0.3945" width="0.0762" layer="21" curve="-90"/>
-<wire x1="-0.712" y1="0.3945" x2="0.712" y2="0.3945" width="0.0762" layer="21"/>
-</package>
-</packages>
-<packages3d>
-<package3d name="L0402" urn="urn:adsk.eagle:package:32722/1" type="box" library_version="1">
-<packageinstances>
-<packageinstance name="L0402"/>
-</packageinstances>
-</package3d>
-</packages3d>
-<symbols>
-<symbol name="INDUCTOR/FERRITE-BEAD" urn="urn:adsk.eagle:symbol:32713/1" library_version="1">
-<wire x1="-2.54" y1="0" x2="-1.27" y2="0" width="0.254" layer="94" curve="-180"/>
-<wire x1="-1.27" y1="0" x2="0" y2="0" width="0.254" layer="94" curve="-180"/>
-<wire x1="0" y1="0" x2="1.27" y2="0" width="0.254" layer="94" curve="-180"/>
-<wire x1="1.27" y1="0" x2="2.54" y2="0" width="0.254" layer="94" curve="-180"/>
-<text x="-2.54" y="1.27" size="1.27" layer="95" ratio="10">&gt;NAME</text>
-<text x="-2.54" y="-2.54" size="1.27" layer="96" ratio="10">&gt;VALUE</text>
-<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
-<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
-</symbol>
-<symbol name="SMD-INDUCTOR-4.7NH-0.3NH-300MA(0402)" urn="urn:adsk.eagle:symbol:32711/1" library_version="1">
-<wire x1="-2.54" y1="0" x2="-1.27" y2="0" width="0.254" layer="94" curve="-180"/>
-<wire x1="-1.27" y1="0" x2="0" y2="0" width="0.254" layer="94" curve="-180"/>
-<wire x1="0" y1="0" x2="1.27" y2="0" width="0.254" layer="94" curve="-180"/>
-<wire x1="1.27" y1="0" x2="2.54" y2="0" width="0.254" layer="94" curve="-180"/>
-<text x="-2.54" y="1.27" size="1.27" layer="95" ratio="10">&gt;NAME</text>
-<text x="-2.54" y="-2.54" size="1.27" layer="96" ratio="10">&gt;VALUE</text>
-<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
-<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="SMD-INDUCTOR-3.3NH-0.3NH-300MA(0402)" urn="urn:adsk.eagle:component:32726/1" prefix="L" uservalue="yes" library_version="1">
-<description>303010056</description>
-<gates>
-<gate name="G$1" symbol="INDUCTOR/FERRITE-BEAD" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="L0402">
+<device name="-SMD-4.5MM" package="TACTILE_SWITCH_SMD_4.5MM">
+<connects>
+<connect gate="G$1" pin="1" pad="2 3"/>
+<connect gate="G$1" pin="2" pad="1 4"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450573/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-09213"/>
+</technology>
+</technologies>
+</device>
+<device name="-SMD-4.6X2.8MM" package="TACTILE_SWITCH_SMD_4.6X2.8MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1 2"/>
+<connect gate="G$1" pin="2" pad="3 4"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450572/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-13065"/>
+</technology>
+</technologies>
+</device>
+<device name="-SMD-5.2-REDUNDANT" package="TACTILE_SWITCH_SMD_5.2MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1 2"/>
+<connect gate="G$1" pin="2" pad="3 4"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450571/3"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-08247"/>
+<attribute name="SF_SKU" value="COM-08720"/>
+</technology>
+</technologies>
+</device>
+<device name="-SMD-5.2MM" package="TACTILE_SWITCH_SMD_5.2MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450571/3"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-08247"/>
+<attribute name="SF_SKU" value="COM-08720"/>
+</technology>
+</technologies>
+</device>
+<device name="-SMD-6.0X3.5MM" package="TACTILE_SWITCH_SMD_6.0X3.5MM">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:32722/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450570/1"/>
 </package3dinstances>
 <technologies>
 <technology name="">
-<attribute name="VALUE" value="3.3NH- 300MA" constant="no"/>
+<attribute name="PROD_ID" value="SWCH-00815"/>
+<attribute name="SF_SKU" value="COM-08229"/>
+</technology>
+</technologies>
+</device>
+<device name="-SMD-6.2MM-TALL" package="TACTILE_SWITCH_SMD_6.2MM_TALL">
+<connects>
+<connect gate="G$1" pin="1" pad="A2"/>
+<connect gate="G$1" pin="2" pad="B2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450569/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-11966"/>
+<attribute name="SF_SKU" value="COM-12992"/>
+</technology>
+</technologies>
+</device>
+<device name="-SMD-12MM" package="TACTILE_SWITCH_SMD_12MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450568/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="SWCH-11967"/>
+<attribute name="SF_SKU" value="COM-12993"/>
+</technology>
+</technologies>
+</device>
+<device name="-SMD-RIGHT-ANGLE" package="TACTILE_SWITCH_SMD_RIGHT_ANGLE">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450567/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="COMP-12265" constant="no"/>
 </technology>
 </technologies>
 </device>
 </devices>
 </deviceset>
-<deviceset name="SMD-INDUCTOR-4.7NH-0.3NH-300MA(0402)" urn="urn:adsk.eagle:component:32733/1" prefix="L" uservalue="yes" library_version="1">
-<description>303010037</description>
+<deviceset name="CHIP-ANTENNA" urn="urn:adsk.eagle:component:35450588/1" library_version="3">
 <gates>
-<gate name="L" symbol="SMD-INDUCTOR-4.7NH-0.3NH-300MA(0402)" x="0" y="0"/>
+<gate name="G$1" symbol="ANTENNA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="L0402">
+<device name="" package="CHIPANTENNA-1206">
 <connects>
-<connect gate="L" pin="1" pad="1"/>
-<connect gate="L" pin="2" pad="2"/>
+<connect gate="G$1" pin="SIGNAL" pad="P$1"/>
 </connects>
 <package3dinstances>
-<package3dinstance package3d_urn="urn:adsk.eagle:package:32722/1"/>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450583/1"/>
 </package3dinstances>
 <technologies>
-<technology name="">
-<attribute name="MPN" value="LQG15HS4N7S02" constant="no"/>
-<attribute name="VALUE" value="4.7NH-300MA"/>
-</technology>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SHORT" package="CHIPANTENNA-1206-SHORT">
+<connects>
+<connect gate="G$1" pin="SIGNAL" pad="P$1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:35450582/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
 </technologies>
 </device>
 </devices>
@@ -5764,20 +5235,21 @@ LED</description>
 </class>
 </classes>
 <parts>
-<part name="IC1" library="bens" deviceset="ESP32-PICO-D4" device="UM-ESP32-PICO-D4"/>
 <part name="+3V1" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
 <part name="+3V2" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
 <part name="+3V3" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
-<part name="U1" library="SparkFun-PowerIC" deviceset="V_REG_AP2112" device="K-3.3V" value="AP2112K-3.3TRG1"/>
-<part name="C2" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" deviceset="0.1UF" device="-0402-16V-10%" package3d_urn="urn:adsk.eagle:package:37413/1" value="0.1uF"/>
-<part name="C1" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" deviceset="1.0UF" device="-0603-16V-10%" package3d_urn="urn:adsk.eagle:package:37414/1" value="1.0uF"/>
+<part name="IC3" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" deviceset="V_REG_AP2112" device="K-3.3V" package3d_urn="urn:adsk.eagle:package:35450579/2" value="3.3V">
+<attribute name="MANF#" value="AP2112K-3.3TRG1"/>
+</part>
+<part name="C2" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="C" device="-0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="0.1uF"/>
+<part name="C1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="C" device="-0603" package3d_urn="urn:adsk.eagle:package:2539457/2" value="1.0uF"/>
 <part name="P+1" library="supply1" deviceset="+5V" device=""/>
-<part name="GND6" library="supply1" deviceset="GND" device=""/>
-<part name="GND7" library="supply1" deviceset="GND" device=""/>
+<part name="GND6" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="GND7" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="+3V5" library="supply1" deviceset="+3V3" device=""/>
 <part name="J1" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" deviceset="CONN_04" device="1X04_NO_SILK" package3d_urn="urn:adsk.eagle:package:38094/1"/>
 <part name="P+2" library="supply1" deviceset="+5V" device=""/>
-<part name="GND3" library="supply1" deviceset="GND" device=""/>
+<part name="GND3" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 <part name="+3V6" library="supply1" deviceset="+3V3" device=""/>
 <part name="P+3" library="supply1" deviceset="+5V" device=""/>
 <part name="TP1" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" deviceset="TEST-POINT" device="3X5" package3d_urn="urn:adsk.eagle:package:38285/1" value="TEST-POINT3X5"/>
@@ -5786,178 +5258,245 @@ LED</description>
 <part name="TP4" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" deviceset="TEST-POINT" device="3X5" package3d_urn="urn:adsk.eagle:package:38285/1" value="TEST-POINT3X5"/>
 <part name="TP5" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" deviceset="TEST-POINT" device="3X5" package3d_urn="urn:adsk.eagle:package:38285/1" value="TEST-POINT3X5"/>
 <part name="TP6" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" deviceset="TEST-POINT" device="3X5" package3d_urn="urn:adsk.eagle:package:38285/1" value="TEST-POINT3X5"/>
-<part name="R3" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="10KOHM" device="-0603-1/10W-1%" package3d_urn="urn:adsk.eagle:package:39650/1" value="10k"/>
-<part name="C3" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" deviceset="10UF" device="-0603-6.3V-20%" package3d_urn="urn:adsk.eagle:package:37414/1" value="10uF"/>
-<part name="U$1" library="SOP50P310X90-8N" deviceset="SN74LVC2T45DCUR" device=""/>
-<part name="GND5" library="supply1" deviceset="GND" device=""/>
-<part name="R1" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="100OHM" device="-0603-1/10W-1%" package3d_urn="urn:adsk.eagle:package:39650/1" value="100"/>
-<part name="R2" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="100OHM" device="-0603-1/10W-1%" package3d_urn="urn:adsk.eagle:package:39650/1" value="100"/>
-<part name="S1" library="SparkFun-Switches" library_urn="urn:adsk.eagle:library:535" deviceset="MOMENTARY-SWITCH-SPST" device="-SMD-5.2MM" package3d_urn="urn:adsk.eagle:package:40167/1"/>
-<part name="GND4" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="GND" device=""/>
-<part name="U$2" library="bens" deviceset="CHIP-ANTENNA" device="SHORT" value="CHIP-ANTENNASHORT"/>
-<part name="D1" library="SparkFun-LED" library_urn="urn:adsk.eagle:library:529" deviceset="LED" device="0603" package3d_urn="urn:adsk.eagle:package:39354/1"/>
-<part name="GND1" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="GND" device=""/>
-<part name="R4" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="100OHM" device="-0603-1/10W-1%" package3d_urn="urn:adsk.eagle:package:39650/1" value="100"/>
-<part name="C4" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" deviceset="0.1UF" device="-0402-16V-10%" package3d_urn="urn:adsk.eagle:package:37413/1" value="0.1uF"/>
-<part name="C5" library="SparkFun-Capacitors" library_urn="urn:adsk.eagle:library:510" deviceset="0.1UF" device="-0402-16V-10%" package3d_urn="urn:adsk.eagle:package:37413/1" value="0.1uF"/>
-<part name="C6" library="Seeed-Capacitor" library_urn="urn:adsk.eagle:library:464" deviceset="CERAMIC-1.5PF-50V-0.1PF-NPO(0402)" device="" package3d_urn="urn:adsk.eagle:package:32379/1" value="1.6PF"/>
-<part name="L1" library="Seeed-Inductor" library_urn="urn:adsk.eagle:library:471" deviceset="SMD-INDUCTOR-3.3NH-0.3NH-300MA(0402)" device="" package3d_urn="urn:adsk.eagle:package:32722/1" value="1.8NH"/>
-<part name="L2" library="Seeed-Inductor" library_urn="urn:adsk.eagle:library:471" deviceset="SMD-INDUCTOR-4.7NH-0.3NH-300MA(0402)" device="" package3d_urn="urn:adsk.eagle:package:32722/1" value="1.8NH"/>
-<part name="GND8" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="GND" device=""/>
+<part name="R3" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0603" package3d_urn="urn:adsk.eagle:package:2539454/2" technology="-1%" value="10k"/>
+<part name="C3" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="C" device="-0603" package3d_urn="urn:adsk.eagle:package:2539457/2" value="10uF"/>
+<part name="IC2" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" deviceset="SN74LVC2T45DCUR" device="" package3d_urn="urn:adsk.eagle:package:35450578/3">
+<attribute name="MANF#" value="SN74LVC2T45DCUR"/>
+</part>
+<part name="GND5" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="R1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0603" package3d_urn="urn:adsk.eagle:package:2539454/2" technology="-1%" value="100"/>
+<part name="R2" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0603" package3d_urn="urn:adsk.eagle:package:2539454/2" technology="-1%" value="100"/>
+<part name="S1" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" deviceset="MOMENTARY-SWITCH-SPST" device="-SMD-5.2MM" package3d_urn="urn:adsk.eagle:package:35450571/3"/>
+<part name="GND4" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="U$2" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" deviceset="CHIP-ANTENNA" device="SHORT" package3d_urn="urn:adsk.eagle:package:35450582/1" override_package3d_urn="urn:adsk.eagle:package:35450582/2" override_package_urn="urn:adsk.eagle:footprint:35450559/1" value="CHIP-ANTENNASHORT"/>
+<part name="LEDD1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="LED" device="-0603" package3d_urn="urn:adsk.eagle:package:2539471/4"/>
+<part name="GND1" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="R4" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="R" device="-0603" package3d_urn="urn:adsk.eagle:package:2539454/2" technology="-1%" value="100"/>
+<part name="C4" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="C" device="-0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="0.1uF"/>
+<part name="C5" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="C" device="-0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="0.1uF"/>
+<part name="C6" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="C" device="-0402" package3d_urn="urn:adsk.eagle:package:2539461/2" value="1.6PF"/>
 <part name="J2" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" deviceset="CONN_04" device="1X04_NO_SILK" package3d_urn="urn:adsk.eagle:package:38094/1"/>
-<part name="GND2" library="supply1" deviceset="GND" device=""/>
+<part name="GND9" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="GND10" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="GND11" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="FRAME1" library="frames" library_urn="urn:adsk.eagle:library:229" deviceset="A4L-LOC" device=""/>
+<part name="+3V4" library="supply1" deviceset="+3V3" device=""/>
+<part name="L2" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="L" device="-0402" package3d_urn="urn:adsk.eagle:package:5347945/2"/>
+<part name="L1" library="rc" library_urn="urn:adsk.eagle:library:2539423" deviceset="L" device="-0402" package3d_urn="urn:adsk.eagle:package:5347945/2"/>
+<part name="GND12" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="GND8" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="GND13" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
+<part name="IC4" library="pixelblaze" library_urn="urn:adsk.eagle:library:35450543" deviceset="ESP32-PICO-D4" device="UM-ESP32-PICO-D4" package3d_urn="urn:adsk.eagle:package:35450580/2"/>
+<part name="GND2" library="supply_symbols" library_urn="urn:adsk.eagle:library:5017758" deviceset="GND" device="" value="GND"/>
 </parts>
 <sheets>
 <sheet>
 <plain>
-<text x="-5.08" y="50.8" size="1.778" layer="97">Output/Power Headers</text>
-<text x="25.4" y="7.62" size="1.778" layer="97">3.3v regulator</text>
-<text x="58.42" y="43.18" size="1.778" layer="97">Level Shifter</text>
-<text x="190.5" y="53.34" size="1.778" layer="97" rot="R90">Magic RF
+<text x="38.1" y="111.76" size="1.778" layer="97" rot="R90">Output/Power Headers</text>
+<text x="53.34" y="73.66" size="1.778" layer="97">3.3v regulator</text>
+<text x="91.44" y="124.46" size="1.778" layer="97">Level Shifter</text>
+<text x="213.36" y="124.46" size="1.778" layer="97" font="vector" rot="R180" align="center">Magic RF
 Matching Network</text>
-<text x="58.42" y="45.72" size="1.778" layer="97">SN74LVC2T45DCUR</text>
 </plain>
 <instances>
-<instance part="IC1" gate="G$1" x="124.46" y="48.26" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="137.16" y="50.8" size="1.27" layer="95" rot="MR0"/>
+<instance part="+3V1" gate="G$1" x="190.5" y="139.7" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="185.42" y="134.62" size="1.778" layer="96" rot="MR90"/>
 </instance>
-<instance part="+3V1" gate="G$1" x="162.56" y="88.9" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="157.48" y="83.82" size="1.778" layer="96" rot="MR90"/>
+<instance part="+3V2" gate="G$1" x="144.78" y="139.7" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="147.32" y="134.62" size="1.778" layer="96" rot="MR90"/>
 </instance>
-<instance part="+3V2" gate="G$1" x="116.84" y="88.9" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="119.38" y="83.82" size="1.778" layer="96" rot="MR90"/>
+<instance part="+3V3" gate="G$1" x="157.48" y="60.96" smashed="yes" rot="MR180">
+<attribute name="VALUE" x="154.94" y="66.04" size="1.778" layer="96" rot="MR270"/>
 </instance>
-<instance part="+3V3" gate="G$1" x="114.3" y="15.24" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="116.84" y="10.16" size="1.778" layer="96" rot="MR90"/>
+<instance part="IC3" gate="G$1" x="53.34" y="81.28" smashed="yes">
+<attribute name="NAME" x="60.96" y="92.964" size="1.778" layer="95" font="vector" ratio="12" align="center"/>
+<attribute name="MANF#" x="60.96" y="80.01" size="1.27" layer="96" font="vector" align="center"/>
 </instance>
-<instance part="IC1" gate="G$2" x="139.7" y="35.56" smashed="yes" rot="MR270"/>
-<instance part="U1" gate="G$1" x="33.02" y="22.86" smashed="yes">
-<attribute name="NAME" x="25.4" y="32.004" size="1.778" layer="95"/>
-<attribute name="VALUE" x="25.4" y="11.43" size="1.778" layer="96"/>
+<instance part="C2" gate="G$1" x="81.28" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="80.391" y="82.55" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="81.534" y="85.09" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="80.772" y="85.852" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="81.788" y="82.804" size="0.508" layer="97" font="vector" rot="R270" align="center-left"/>
+<attribute name="ALLOCATED" x="83.82" y="83.82" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
 </instance>
-<instance part="C2" gate="G$1" x="53.34" y="22.86" smashed="yes">
-<attribute name="NAME" x="54.864" y="25.781" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="54.864" y="20.701" size="1.778" layer="96" font="vector"/>
+<instance part="C1" gate="G$1" x="43.18" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="42.291" y="82.55" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="43.434" y="85.09" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="42.672" y="85.852" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="43.688" y="82.804" size="0.508" layer="97" font="vector" rot="R270" align="center-left"/>
+<attribute name="ALLOCATED" x="45.72" y="83.82" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
 </instance>
-<instance part="C1" gate="G$1" x="12.7" y="22.86" smashed="yes">
-<attribute name="NAME" x="14.224" y="25.781" size="1.778" layer="95"/>
-<attribute name="VALUE" x="14.224" y="20.701" size="1.778" layer="96"/>
+<instance part="P+1" gate="1" x="43.18" y="93.98" smashed="yes">
+<attribute name="VALUE" x="40.64" y="88.9" size="1.778" layer="96" rot="R90"/>
 </instance>
-<instance part="P+1" gate="1" x="12.7" y="35.56" smashed="yes">
-<attribute name="VALUE" x="10.16" y="30.48" size="1.778" layer="96" rot="R90"/>
+<instance part="GND6" gate="1" x="43.18" y="76.2" smashed="yes">
+<attribute name="VALUE" x="43.18" y="74.93" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND6" gate="1" x="12.7" y="5.08" smashed="yes">
-<attribute name="VALUE" x="10.16" y="2.54" size="1.778" layer="96"/>
+<instance part="GND7" gate="1" x="91.44" y="76.2" smashed="yes">
+<attribute name="VALUE" x="91.44" y="74.93" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND7" gate="1" x="73.66" y="5.08" smashed="yes">
-<attribute name="VALUE" x="71.12" y="2.54" size="1.778" layer="96"/>
+<instance part="+3V5" gate="G$1" x="91.44" y="93.98" smashed="yes">
+<attribute name="VALUE" x="88.9" y="88.9" size="1.778" layer="96" rot="R90"/>
 </instance>
-<instance part="+3V5" gate="G$1" x="73.66" y="35.56" smashed="yes">
-<attribute name="VALUE" x="71.12" y="30.48" size="1.778" layer="96" rot="R90"/>
+<instance part="J1" gate="G$1" x="45.72" y="129.54" smashed="yes">
+<attribute name="VALUE" x="40.64" y="122.174" size="1.778" layer="96" font="vector"/>
+<attribute name="NAME" x="40.64" y="137.668" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="J1" gate="G$1" x="5.08" y="60.96" smashed="yes">
-<attribute name="VALUE" x="0" y="53.594" size="1.778" layer="96" font="vector"/>
-<attribute name="NAME" x="0" y="69.088" size="1.778" layer="95" font="vector"/>
+<instance part="P+2" gate="1" x="60.96" y="142.24" smashed="yes">
+<attribute name="VALUE" x="58.42" y="137.16" size="1.778" layer="96" rot="R90"/>
 </instance>
-<instance part="P+2" gate="1" x="22.86" y="78.74" smashed="yes">
-<attribute name="VALUE" x="20.32" y="73.66" size="1.778" layer="96" rot="R90"/>
+<instance part="GND3" gate="1" x="53.34" y="104.14" smashed="yes">
+<attribute name="VALUE" x="53.34" y="102.87" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND3" gate="1" x="22.86" y="45.72" smashed="yes">
-<attribute name="VALUE" x="20.32" y="43.18" size="1.778" layer="96"/>
+<instance part="+3V6" gate="G$1" x="114.3" y="121.92" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="116.84" y="116.84" size="1.778" layer="96" rot="MR90"/>
 </instance>
-<instance part="+3V6" gate="G$1" x="83.82" y="88.9" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="86.36" y="83.82" size="1.778" layer="96" rot="MR90"/>
+<instance part="P+3" gate="1" x="83.82" y="121.92" smashed="yes">
+<attribute name="VALUE" x="81.28" y="116.84" size="1.778" layer="96" rot="R90"/>
 </instance>
-<instance part="P+3" gate="1" x="53.34" y="78.74" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="55.88" y="73.66" size="1.778" layer="96" rot="MR90"/>
+<instance part="TP1" gate="G$1" x="152.4" y="132.08" smashed="yes" rot="MR90">
+<attribute name="NAME" x="151.638" y="137.16" size="1.778" layer="95" font="vector" rot="MR90"/>
 </instance>
-<instance part="TP1" gate="G$1" x="124.46" y="81.28" smashed="yes" rot="MR90">
-<attribute name="NAME" x="123.698" y="86.36" size="1.778" layer="95" font="vector" rot="MR90"/>
+<instance part="TP2" gate="G$1" x="154.94" y="132.08" smashed="yes" rot="MR90">
+<attribute name="NAME" x="154.178" y="137.16" size="1.778" layer="95" font="vector" rot="MR90"/>
 </instance>
-<instance part="TP2" gate="G$1" x="127" y="81.28" smashed="yes" rot="MR90">
-<attribute name="NAME" x="126.238" y="86.36" size="1.778" layer="95" font="vector" rot="MR90"/>
+<instance part="TP3" gate="G$1" x="193.04" y="91.44" smashed="yes" rot="MR180">
+<attribute name="NAME" x="197.104" y="92.456" size="1.778" layer="95" font="vector" rot="MR180"/>
 </instance>
-<instance part="TP3" gate="G$1" x="165.1" y="40.64" smashed="yes" rot="MR180">
-<attribute name="NAME" x="169.164" y="41.656" size="1.778" layer="95" font="vector" rot="MR180"/>
+<instance part="TP4" gate="G$1" x="147.32" y="63.5" smashed="yes" rot="MR270">
+<attribute name="NAME" x="144.78" y="66.04" size="1.778" layer="95" font="vector" rot="MR270"/>
 </instance>
-<instance part="TP4" gate="G$1" x="101.6" y="12.7" smashed="yes" rot="MR0">
-<attribute name="NAME" x="104.14" y="15.24" size="1.778" layer="95" font="vector" rot="MR0"/>
+<instance part="TP5" gate="G$1" x="99.06" y="88.9" smashed="yes" rot="MR180">
+<attribute name="NAME" x="96.52" y="91.44" size="1.778" layer="95" font="vector" rot="MR180"/>
 </instance>
-<instance part="TP5" gate="G$1" x="78.74" y="27.94" smashed="yes" rot="MR180">
-<attribute name="NAME" x="76.2" y="30.48" size="1.778" layer="95" font="vector" rot="MR180"/>
+<instance part="TP6" gate="G$1" x="99.06" y="81.28" smashed="yes" rot="MR180">
+<attribute name="NAME" x="96.52" y="83.82" size="1.778" layer="95" font="vector" rot="MR180"/>
 </instance>
-<instance part="TP6" gate="G$1" x="78.74" y="10.16" smashed="yes" rot="MR180">
-<attribute name="NAME" x="76.2" y="12.7" size="1.778" layer="95" font="vector" rot="MR180"/>
+<instance part="R3" gate="G$1" x="190.5" y="96.52" smashed="yes" rot="MR270">
+<attribute name="NAME" x="190.5" y="96.52" size="1.27" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="VALUE" x="192.532" y="96.774" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="189.992" y="100.33" size="0.508" layer="95" font="vector" rot="MR270" align="center"/>
+<attribute name="TOLERANCE" x="192.532" y="96.266" size="0.762" layer="96" font="vector" rot="MR270"/>
+<attribute name="ALLOCATED" x="188.976" y="96.52" size="0.762" layer="97" font="vector" rot="MR270" align="center"/>
 </instance>
-<instance part="R3" gate="G$1" x="162.56" y="45.72" smashed="yes" rot="MR270">
-<attribute name="NAME" x="161.036" y="45.72" size="1.778" layer="95" font="vector" rot="MR270" align="bottom-center"/>
-<attribute name="VALUE" x="164.084" y="45.72" size="1.778" layer="96" font="vector" rot="MR270" align="top-center"/>
+<instance part="C3" gate="G$1" x="76.2" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="75.311" y="82.55" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="76.454" y="85.09" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="75.692" y="85.852" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="76.708" y="82.804" size="0.508" layer="97" font="vector" rot="R270" align="center-left"/>
+<attribute name="ALLOCATED" x="78.74" y="83.82" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
 </instance>
-<instance part="C3" gate="G$1" x="43.18" y="22.86" smashed="yes">
-<attribute name="NAME" x="44.704" y="25.781" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="44.704" y="20.701" size="1.778" layer="96" font="vector"/>
+<instance part="IC2" gate="G$1" x="109.22" y="106.68" smashed="yes" rot="MR0">
+<attribute name="NAME" x="99.06" y="121.92" size="2.54" layer="95" font="vector" ratio="12" rot="MR0" align="center"/>
+<attribute name="MANF#" x="99.06" y="105.41" size="1.27" layer="95" font="vector" ratio="12" rot="MR0" align="center"/>
 </instance>
-<instance part="U$1" gate="G$1" x="68.58" y="60.96" smashed="yes" rot="MR0"/>
-<instance part="GND5" gate="1" x="83.82" y="45.72" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="86.36" y="43.18" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND5" gate="1" x="114.3" y="104.14" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="114.3" y="102.87" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
-<instance part="R1" gate="G$1" x="48.26" y="63.5" smashed="yes" rot="MR0">
-<attribute name="NAME" x="48.26" y="65.024" size="1.778" layer="95" font="vector" rot="MR0" align="bottom-center"/>
-<attribute name="VALUE" x="43.18" y="67.056" size="1.778" layer="96" font="vector" rot="MR0" align="top-center"/>
+<instance part="R1" gate="G$1" x="78.74" y="114.3" smashed="yes" rot="MR0">
+<attribute name="NAME" x="78.74" y="114.3" size="1.27" layer="95" font="vector" rot="MR0" align="center"/>
+<attribute name="VALUE" x="78.994" y="112.268" size="0.762" layer="96" font="vector" rot="MR0" align="bottom-right"/>
+<attribute name="PACKAGE" x="82.55" y="114.808" size="0.508" layer="95" font="vector" rot="MR0" align="center"/>
+<attribute name="TOLERANCE" x="78.486" y="112.268" size="0.762" layer="96" font="vector" rot="MR0"/>
+<attribute name="ALLOCATED" x="78.74" y="115.824" size="0.762" layer="97" font="vector" rot="MR0" align="center"/>
 </instance>
-<instance part="R2" gate="G$1" x="48.26" y="58.42" smashed="yes" rot="MR0">
-<attribute name="NAME" x="48.26" y="59.944" size="1.778" layer="95" font="vector" rot="MR0" align="bottom-center"/>
-<attribute name="VALUE" x="43.18" y="61.976" size="1.778" layer="96" font="vector" rot="MR0" align="top-center"/>
+<instance part="R2" gate="G$1" x="71.12" y="111.76" smashed="yes" rot="MR0">
+<attribute name="NAME" x="71.12" y="111.76" size="1.27" layer="95" font="vector" rot="MR0" align="center"/>
+<attribute name="VALUE" x="71.374" y="109.728" size="0.762" layer="96" font="vector" rot="MR0" align="bottom-right"/>
+<attribute name="PACKAGE" x="74.93" y="112.268" size="0.508" layer="95" font="vector" rot="MR0" align="center"/>
+<attribute name="TOLERANCE" x="70.866" y="109.728" size="0.762" layer="96" font="vector" rot="MR0"/>
+<attribute name="ALLOCATED" x="71.12" y="113.284" size="0.762" layer="97" font="vector" rot="MR0" align="center"/>
 </instance>
-<instance part="S1" gate="G$1" x="170.18" y="22.86" smashed="yes" rot="R90">
-<attribute name="NAME" x="168.656" y="22.86" size="1.778" layer="95" font="vector" rot="R90" align="bottom-center"/>
+<instance part="S1" gate="G$1" x="200.66" y="83.82" smashed="yes" rot="MR0">
+<attribute name="NAME" x="200.66" y="85.344" size="1.778" layer="95" font="vector" rot="MR0" align="bottom-center"/>
 </instance>
-<instance part="GND4" gate="1" x="170.18" y="5.08" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="172.72" y="2.54" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND4" gate="1" x="208.28" y="78.74" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="208.28" y="77.47" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
-<instance part="U$2" gate="G$1" x="172.72" y="76.2" smashed="yes" rot="MR0">
-<attribute name="NAME" x="172.212" y="76.2" size="1.778" layer="95" font="vector" rot="MR0"/>
+<instance part="U$2" gate="G$1" x="200.66" y="132.08" smashed="yes" rot="MR0">
+<attribute name="NAME" x="200.152" y="132.08" size="1.778" layer="95" font="vector" rot="MR0"/>
 </instance>
-<instance part="D1" gate="G$1" x="124.46" y="12.7" smashed="yes" rot="MR270">
-<attribute name="NAME" x="129.032" y="16.129" size="1.778" layer="95" font="vector" rot="MR0"/>
-<attribute name="VALUE" x="129.032" y="10.795" size="1.778" layer="96" font="vector" rot="MR0" align="top-left"/>
+<instance part="LEDD1" gate="G$1" x="162.56" y="60.96" smashed="yes" rot="R270">
+<attribute name="NAME" x="160.02" y="63.5" size="1.27" layer="95" font="vector" ratio="15" rot="R270" align="center"/>
+<attribute name="COLOR" x="163.068" y="63.754" size="0.635" layer="96" font="vector" rot="R270" align="center-right"/>
+<attribute name="PACKAGE" x="162.052" y="63.754" size="0.635" layer="96" font="vector" rot="R270" align="center-right"/>
 </instance>
-<instance part="GND1" gate="1" x="142.24" y="5.08" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="144.78" y="2.54" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND1" gate="1" x="162.56" y="40.64" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="162.56" y="39.37" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
-<instance part="R4" gate="G$1" x="137.16" y="12.7" smashed="yes" rot="MR0">
-<attribute name="NAME" x="137.16" y="14.224" size="1.778" layer="95" font="vector" rot="MR0" align="bottom-center"/>
-<attribute name="VALUE" x="137.16" y="11.176" size="1.778" layer="96" font="vector" rot="MR0" align="top-center"/>
+<instance part="R4" gate="G$1" x="162.56" y="50.8" smashed="yes" rot="MR90">
+<attribute name="NAME" x="162.56" y="50.8" size="1.27" layer="95" font="vector" rot="MR90" align="center"/>
+<attribute name="VALUE" x="160.528" y="50.546" size="0.762" layer="96" font="vector" rot="MR90" align="bottom-right"/>
+<attribute name="PACKAGE" x="163.068" y="46.99" size="0.508" layer="95" font="vector" rot="MR90" align="center"/>
+<attribute name="TOLERANCE" x="160.528" y="51.054" size="0.762" layer="96" font="vector" rot="MR90"/>
+<attribute name="ALLOCATED" x="164.084" y="50.8" size="0.762" layer="97" font="vector" rot="MR90" align="center"/>
 </instance>
-<instance part="C4" gate="G$1" x="63.5" y="22.86" smashed="yes">
-<attribute name="NAME" x="65.024" y="25.781" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="65.024" y="20.701" size="1.778" layer="96" font="vector"/>
+<instance part="C4" gate="G$1" x="86.36" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="85.471" y="82.55" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="86.614" y="85.09" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="85.852" y="85.852" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="86.868" y="82.804" size="0.508" layer="97" font="vector" rot="R270" align="center-left"/>
+<attribute name="ALLOCATED" x="88.9" y="83.82" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
 </instance>
-<instance part="C5" gate="G$1" x="73.66" y="22.86" smashed="yes">
-<attribute name="NAME" x="75.184" y="25.781" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="75.184" y="20.701" size="1.778" layer="96" font="vector"/>
+<instance part="C5" gate="G$1" x="91.44" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="90.551" y="82.55" size="1.27" layer="95" font="vector" rot="R270" align="center-left"/>
+<attribute name="VALUE" x="91.694" y="85.09" size="0.762" layer="96" font="vector" rot="R270" align="bottom-right"/>
+<attribute name="PACKAGE" x="90.932" y="85.852" size="0.508" layer="97" font="vector" rot="R90" align="center"/>
+<attribute name="VOLTAGE" x="91.948" y="82.804" size="0.508" layer="97" font="vector" rot="R270" align="center-left"/>
+<attribute name="ALLOCATED" x="93.98" y="83.82" size="0.508" layer="97" font="vector" rot="R270" align="center"/>
 </instance>
-<instance part="C6" gate="G$1" x="172.72" y="63.5" smashed="yes" rot="MR270">
-<attribute name="NAME" x="170.18" y="65.786" size="1.27" layer="95" ratio="10" rot="MR270"/>
-<attribute name="VALUE" x="170.18" y="62.23" size="1.27" layer="96" ratio="10" rot="MR270"/>
+<instance part="C6" gate="G$1" x="200.66" y="114.3" smashed="yes" rot="MR270">
+<attribute name="NAME" x="201.549" y="113.03" size="1.27" layer="95" font="vector" rot="MR270" align="center-left"/>
+<attribute name="VALUE" x="200.406" y="115.57" size="0.762" layer="96" font="vector" rot="MR270" align="bottom-right"/>
+<attribute name="PACKAGE" x="201.168" y="116.332" size="0.508" layer="97" font="vector" rot="MR90" align="center"/>
+<attribute name="VOLTAGE" x="200.152" y="113.284" size="0.508" layer="97" font="vector" rot="MR270" align="center-left"/>
+<attribute name="ALLOCATED" x="198.12" y="114.3" size="0.508" layer="97" font="vector" rot="MR270" align="center"/>
 </instance>
-<instance part="L1" gate="G$1" x="177.8" y="58.42" smashed="yes" rot="MR0">
-<attribute name="NAME" x="180.34" y="59.69" size="1.27" layer="95" ratio="10" rot="MR0"/>
-<attribute name="VALUE" x="180.34" y="55.88" size="1.27" layer="96" ratio="10" rot="MR0"/>
+<instance part="J2" gate="G$1" x="45.72" y="111.76" smashed="yes">
+<attribute name="VALUE" x="40.64" y="104.394" size="1.778" layer="96" font="vector"/>
+<attribute name="NAME" x="40.64" y="119.888" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="L2" gate="L" x="177.8" y="68.58" smashed="yes" rot="MR0">
-<attribute name="NAME" x="180.34" y="69.85" size="1.27" layer="95" ratio="10" rot="MR0"/>
-<attribute name="VALUE" x="180.34" y="66.04" size="1.27" layer="96" ratio="10" rot="MR0"/>
+<instance part="GND9" gate="1" x="86.36" y="76.2" smashed="yes">
+<attribute name="VALUE" x="86.36" y="74.93" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND8" gate="1" x="182.88" y="45.72" smashed="yes" rot="MR0">
-<attribute name="VALUE" x="185.42" y="43.18" size="1.778" layer="96" rot="MR0"/>
+<instance part="GND10" gate="1" x="81.28" y="76.2" smashed="yes">
+<attribute name="VALUE" x="81.28" y="74.93" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="J2" gate="G$1" x="17.78" y="60.96" smashed="yes">
-<attribute name="VALUE" x="12.7" y="53.594" size="1.778" layer="96" font="vector"/>
-<attribute name="NAME" x="12.7" y="69.088" size="1.778" layer="95" font="vector"/>
+<instance part="GND11" gate="1" x="76.2" y="76.2" smashed="yes">
+<attribute name="VALUE" x="76.2" y="74.93" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
 </instance>
-<instance part="GND2" gate="1" x="152.4" y="5.08" smashed="yes">
-<attribute name="VALUE" x="149.86" y="2.54" size="1.778" layer="96"/>
+<instance part="FRAME1" gate="G$1" x="0" y="0" smashed="yes">
+<attribute name="DRAWING_NAME" x="217.17" y="15.24" size="2.54" layer="94"/>
+<attribute name="LAST_DATE_TIME" x="217.17" y="10.16" size="2.286" layer="94"/>
+<attribute name="SHEET" x="230.505" y="5.08" size="2.54" layer="94"/>
+</instance>
+<instance part="+3V4" gate="G$1" x="78.74" y="109.22" smashed="yes" rot="R90">
+<attribute name="VALUE" x="83.82" y="106.68" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="L2" gate="G$1" x="208.28" y="109.22" smashed="yes">
+<attribute name="VALUE" x="208.28" y="108.458" size="0.889" layer="96" font="vector" ratio="15" align="center"/>
+<attribute name="NAME" x="208.28" y="110.998" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
+<attribute name="ALLOCATED" x="204.47" y="109.982" size="0.889" layer="97" font="vector" ratio="15" align="center"/>
+</instance>
+<instance part="L1" gate="G$1" x="208.28" y="119.38" smashed="yes">
+<attribute name="VALUE" x="208.28" y="118.618" size="0.889" layer="96" font="vector" ratio="15" align="center"/>
+<attribute name="NAME" x="208.28" y="121.158" size="1.27" layer="95" font="vector" ratio="15" align="center"/>
+<attribute name="ALLOCATED" x="204.47" y="120.142" size="0.889" layer="97" font="vector" ratio="15" align="center"/>
+</instance>
+<instance part="GND12" gate="1" x="215.9" y="104.14" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="215.9" y="102.87" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
+</instance>
+<instance part="GND8" gate="1" x="48.26" y="76.2" smashed="yes">
+<attribute name="VALUE" x="48.26" y="74.93" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+</instance>
+<instance part="GND13" gate="1" x="96.52" y="76.2" smashed="yes">
+<attribute name="VALUE" x="96.52" y="74.93" size="1.27" layer="96" font="vector" ratio="15" align="center"/>
+</instance>
+<instance part="IC4" gate="G$1" x="185.42" y="71.12" smashed="yes" rot="MR0">
+<attribute name="NAME" x="160.02" y="100.838" size="2.54" layer="95" font="vector" ratio="12" rot="MR0" align="center"/>
+</instance>
+<instance part="GND2" gate="1" x="187.96" y="63.5" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="187.96" y="62.23" size="1.27" layer="96" font="vector" ratio="15" rot="MR0" align="center"/>
 </instance>
 </instances>
 <busses>
@@ -5966,309 +5505,317 @@ Matching Network</text>
 <net name="N$1" class="0">
 <segment>
 <pinref part="U$2" gate="G$1" pin="SIGNAL"/>
-<wire x1="172.72" y1="67.31" x2="172.72" y2="68.58" width="0.1524" layer="91"/>
 <pinref part="C6" gate="G$1" pin="1"/>
-<pinref part="L2" gate="L" pin="2"/>
-<wire x1="172.72" y1="68.58" x2="172.72" y2="71.12" width="0.1524" layer="91"/>
-<junction x="172.72" y="68.58"/>
+<pinref part="L1" gate="G$1" pin="P$1"/>
+<wire x1="200.66" y1="116.84" x2="200.66" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="200.66" y1="119.38" x2="200.66" y2="127" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="119.38" x2="200.66" y2="119.38" width="0.1524" layer="91"/>
+<junction x="200.66" y="119.38"/>
 </segment>
 </net>
 <net name="GND" class="0">
 <segment>
 <pinref part="C1" gate="G$1" pin="2"/>
 <pinref part="GND6" gate="1" pin="GND"/>
-<wire x1="12.7" y1="7.62" x2="12.7" y2="17.78" width="0.1524" layer="91"/>
-<pinref part="U1" gate="G$1" pin="GND"/>
-<wire x1="12.7" y1="17.78" x2="12.7" y2="20.32" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="17.78" x2="12.7" y2="17.78" width="0.1524" layer="91"/>
-<junction x="12.7" y="17.78"/>
+<wire x1="43.18" y1="78.74" x2="43.18" y2="81.28" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<pinref part="IC1" gate="G$2" pin="GNDPAD"/>
-<pinref part="GND2" gate="1" pin="GND"/>
-<wire x1="142.24" y1="35.56" x2="142.24" y2="17.78" width="0.1524" layer="91"/>
-<wire x1="142.24" y1="17.78" x2="152.4" y2="17.78" width="0.1524" layer="91"/>
-<wire x1="152.4" y1="17.78" x2="152.4" y2="7.62" width="0.1524" layer="91"/>
+<pinref part="IC3" gate="G$1" pin="GND"/>
+<pinref part="GND8" gate="1" pin="GND"/>
+<wire x1="48.26" y1="78.74" x2="48.26" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="83.82" x2="48.26" y2="83.82" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C3" gate="G$1" pin="2"/>
+<pinref part="GND11" gate="1" pin="GND"/>
+<wire x1="76.2" y1="78.74" x2="76.2" y2="81.28" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="C2" gate="G$1" pin="2"/>
-<pinref part="GND7" gate="1" pin="GND"/>
-<pinref part="C3" gate="G$1" pin="2"/>
-<pinref part="C5" gate="G$1" pin="2"/>
+<pinref part="GND10" gate="1" pin="GND"/>
+<wire x1="81.28" y1="78.74" x2="81.28" y2="81.28" width="0.1524" layer="91"/>
+</segment>
+<segment>
 <pinref part="C4" gate="G$1" pin="2"/>
-<junction x="63.5" y="20.32"/>
-<junction x="43.18" y="20.32"/>
-<wire x1="73.66" y1="20.32" x2="73.66" y2="10.16" width="0.1524" layer="91"/>
-<junction x="73.66" y="20.32"/>
-<wire x1="73.66" y1="10.16" x2="73.66" y2="7.62" width="0.1524" layer="91"/>
-<wire x1="43.18" y1="20.32" x2="53.34" y2="20.32" width="0.1524" layer="91"/>
-<junction x="53.34" y="20.32"/>
-<wire x1="53.34" y1="20.32" x2="63.5" y2="20.32" width="0.1524" layer="91"/>
-<wire x1="63.5" y1="20.32" x2="73.66" y2="20.32" width="0.1524" layer="91"/>
+<pinref part="GND9" gate="1" pin="GND"/>
+<wire x1="86.36" y1="78.74" x2="86.36" y2="81.28" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="GND7" gate="1" pin="GND"/>
+<pinref part="C5" gate="G$1" pin="2"/>
+<wire x1="91.44" y1="81.28" x2="91.44" y2="78.74" width="0.1524" layer="91"/>
+</segment>
+<segment>
 <pinref part="TP6" gate="G$1" pin="1"/>
-<wire x1="78.74" y1="10.16" x2="73.66" y2="10.16" width="0.1524" layer="91"/>
-<junction x="73.66" y="10.16"/>
+<wire x1="99.06" y1="81.28" x2="96.52" y2="81.28" width="0.1524" layer="91"/>
+<pinref part="GND13" gate="1" pin="GND"/>
+<wire x1="96.52" y1="78.74" x2="96.52" y2="81.28" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="J1" gate="G$1" pin="1"/>
 <pinref part="GND3" gate="1" pin="GND"/>
-<wire x1="22.86" y1="58.42" x2="22.86" y2="53.34" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="53.34" x2="22.86" y2="48.26" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="58.42" x2="10.16" y2="58.42" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="1"/>
-<junction x="22.86" y="58.42"/>
+<wire x1="53.34" y1="106.68" x2="53.34" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="109.22" x2="53.34" y2="127" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="127" x2="50.8" y2="127" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="109.22" x2="53.34" y2="109.22" width="0.1524" layer="91"/>
+<junction x="53.34" y="109.22"/>
 </segment>
 <segment>
-<pinref part="U$1" gate="G$1" pin="GND"/>
+<pinref part="IC2" gate="G$1" pin="GND"/>
 <pinref part="GND5" gate="1" pin="GND"/>
-<wire x1="83.82" y1="53.34" x2="83.82" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="114.3" y1="106.68" x2="114.3" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="114.3" y1="109.22" x2="111.76" y2="109.22" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="S1" gate="G$1" pin="1"/>
 <pinref part="GND4" gate="1" pin="GND"/>
-<wire x1="170.18" y1="7.62" x2="170.18" y2="17.78" width="0.1524" layer="91"/>
+<wire x1="208.28" y1="81.28" x2="208.28" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="208.28" y1="83.82" x2="205.74" y2="83.82" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="GND1" gate="1" pin="GND"/>
 <pinref part="R4" gate="G$1" pin="1"/>
-<wire x1="142.24" y1="7.62" x2="142.24" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="162.56" y1="43.18" x2="162.56" y2="45.72" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<pinref part="L2" gate="L" pin="1"/>
-<pinref part="GND8" gate="1" pin="GND"/>
-<pinref part="L1" gate="G$1" pin="1"/>
-<wire x1="182.88" y1="58.42" x2="182.88" y2="68.58" width="0.1524" layer="91"/>
-<junction x="182.88" y="58.42"/>
-<wire x1="182.88" y1="58.42" x2="182.88" y2="48.26" width="0.1524" layer="91"/>
+<pinref part="L2" gate="G$1" pin="P$2"/>
+<pinref part="GND12" gate="1" pin="GND"/>
+<pinref part="L1" gate="G$1" pin="P$2"/>
+<wire x1="213.36" y1="119.38" x2="215.9" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="215.9" y1="106.68" x2="215.9" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="215.9" y1="109.22" x2="215.9" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="213.36" y1="109.22" x2="215.9" y2="109.22" width="0.1524" layer="91"/>
+<junction x="215.9" y="109.22"/>
+</segment>
+<segment>
+<pinref part="GND2" gate="1" pin="GND"/>
+<pinref part="IC4" gate="G$1" pin="GNDPAD"/>
+<wire x1="187.96" y1="66.04" x2="187.96" y2="68.58" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="+3V3" class="0">
 <segment>
-<pinref part="IC1" gate="G$1" pin="VDD3P3_CPU"/>
 <pinref part="+3V2" gate="G$1" pin="+3V3"/>
-<wire x1="116.84" y1="76.2" x2="116.84" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="144.78" y1="127" x2="144.78" y2="137.16" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="VDD3P3_CPU"/>
 </segment>
 <segment>
-<pinref part="IC1" gate="G$1" pin="VDD3P3_RTC"/>
-<wire x1="116.84" y1="20.32" x2="116.84" y2="7.62" width="0.1524" layer="91"/>
-<wire x1="116.84" y1="7.62" x2="114.3" y2="7.62" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="68.58" x2="157.48" y2="63.5" width="0.1524" layer="91"/>
 <pinref part="+3V3" gate="G$1" pin="+3V3"/>
-<wire x1="114.3" y1="7.62" x2="114.3" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="VDD3P3_RTC"/>
 </segment>
 <segment>
-<pinref part="U1" gate="G$1" pin="OUT"/>
+<pinref part="IC3" gate="G$1" pin="OUT"/>
 <pinref part="C3" gate="G$1" pin="1"/>
-<junction x="43.18" y="27.94"/>
-<wire x1="43.18" y1="27.94" x2="40.64" y2="27.94" width="0.1524" layer="91"/>
 <pinref part="C2" gate="G$1" pin="1"/>
-<junction x="53.34" y="27.94"/>
-<wire x1="53.34" y1="27.94" x2="43.18" y2="27.94" width="0.1524" layer="91"/>
-<wire x1="58.42" y1="27.94" x2="53.34" y2="27.94" width="0.1524" layer="91"/>
 <pinref part="C4" gate="G$1" pin="1"/>
-<junction x="63.5" y="27.94"/>
-<wire x1="63.5" y1="27.94" x2="58.42" y2="27.94" width="0.1524" layer="91"/>
 <pinref part="C5" gate="G$1" pin="1"/>
-<wire x1="73.66" y1="27.94" x2="63.5" y2="27.94" width="0.1524" layer="91"/>
 <pinref part="+3V5" gate="G$1" pin="+3V3"/>
-<wire x1="73.66" y1="33.02" x2="73.66" y2="27.94" width="0.1524" layer="91"/>
-<junction x="73.66" y="27.94"/>
+<wire x1="91.44" y1="91.44" x2="91.44" y2="88.9" width="0.1524" layer="91"/>
 <pinref part="TP5" gate="G$1" pin="1"/>
-<wire x1="78.74" y1="27.94" x2="73.66" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="88.9" x2="91.44" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="88.9" x2="71.12" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="86.36" x2="76.2" y2="88.9" width="0.1524" layer="91"/>
+<junction x="76.2" y="88.9"/>
+<wire x1="76.2" y1="88.9" x2="81.28" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="88.9" x2="86.36" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="86.36" x2="81.28" y2="88.9" width="0.1524" layer="91"/>
+<junction x="81.28" y="88.9"/>
+<wire x1="86.36" y1="86.36" x2="86.36" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="99.06" y1="88.9" x2="91.44" y2="88.9" width="0.1524" layer="91"/>
+<junction x="91.44" y="88.9"/>
+<wire x1="86.36" y1="88.9" x2="91.44" y2="88.9" width="0.1524" layer="91"/>
+<junction x="86.36" y="88.9"/>
 </segment>
 <segment>
 <pinref part="R3" gate="G$1" pin="1"/>
-<pinref part="IC1" gate="G$1" pin="VDDA"/>
-<wire x1="157.48" y1="60.96" x2="162.56" y2="60.96" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="60.96" x2="162.56" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="111.76" x2="190.5" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="190.5" y1="111.76" x2="190.5" y2="132.08" width="0.1524" layer="91"/>
 <pinref part="+3V1" gate="G$1" pin="+3V3"/>
-<pinref part="IC1" gate="G$1" pin="VDDA3P3_1"/>
-<wire x1="162.56" y1="81.28" x2="162.56" y2="86.36" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="55.88" x2="162.56" y2="55.88" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="55.88" x2="162.56" y2="60.96" width="0.1524" layer="91"/>
-<junction x="162.56" y="60.96"/>
-<pinref part="IC1" gate="G$1" pin="VDDA_3P3"/>
-<wire x1="157.48" y1="53.34" x2="162.56" y2="53.34" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="53.34" x2="162.56" y2="55.88" width="0.1524" layer="91"/>
-<junction x="162.56" y="55.88"/>
-<pinref part="IC1" gate="G$1" pin="VDDA_2"/>
-<wire x1="132.08" y1="76.2" x2="132.08" y2="81.28" width="0.1524" layer="91"/>
-<wire x1="132.08" y1="81.28" x2="139.7" y2="81.28" width="0.1524" layer="91"/>
-<pinref part="IC1" gate="G$1" pin="VDDA_3"/>
-<wire x1="139.7" y1="76.2" x2="139.7" y2="81.28" width="0.1524" layer="91"/>
-<junction x="139.7" y="81.28"/>
-<junction x="162.56" y="81.28"/>
-<wire x1="162.56" y1="50.8" x2="162.56" y2="53.34" width="0.1524" layer="91"/>
-<junction x="162.56" y="53.34"/>
-<wire x1="139.7" y1="81.28" x2="162.56" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="190.5" y1="132.08" x2="190.5" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="106.68" x2="190.5" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="190.5" y1="106.68" x2="190.5" y2="111.76" width="0.1524" layer="91"/>
+<junction x="190.5" y="111.76"/>
+<wire x1="187.96" y1="104.14" x2="190.5" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="190.5" y1="104.14" x2="190.5" y2="106.68" width="0.1524" layer="91"/>
+<junction x="190.5" y="106.68"/>
+<wire x1="160.02" y1="127" x2="160.02" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="132.08" x2="167.64" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="167.64" y1="127" x2="167.64" y2="132.08" width="0.1524" layer="91"/>
+<junction x="167.64" y="132.08"/>
+<junction x="190.5" y="132.08"/>
+<wire x1="190.5" y1="101.6" x2="190.5" y2="104.14" width="0.1524" layer="91"/>
+<junction x="190.5" y="104.14"/>
+<wire x1="167.64" y1="132.08" x2="190.5" y2="132.08" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="VDDA"/>
+<pinref part="IC4" gate="G$1" pin="VDDA3P3_1"/>
+<pinref part="IC4" gate="G$1" pin="VDDA_2"/>
+<pinref part="IC4" gate="G$1" pin="VDDA_3"/>
+<pinref part="IC4" gate="G$1" pin="VDDA_3P3"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="G$1" pin="DIR"/>
+<pinref part="+3V4" gate="G$1" pin="+3V3"/>
+<wire x1="81.28" y1="109.22" x2="86.36" y2="109.22" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="+3V6" gate="G$1" pin="+3V3"/>
-<pinref part="U$1" gate="G$1" pin="VCCA"/>
-<wire x1="83.82" y1="86.36" x2="83.82" y2="73.66" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="DIR"/>
-<wire x1="83.82" y1="73.66" x2="83.82" y2="68.58" width="0.1524" layer="91"/>
-<wire x1="53.34" y1="53.34" x2="53.34" y2="48.26" width="0.1524" layer="91"/>
-<wire x1="53.34" y1="48.26" x2="66.04" y2="48.26" width="0.1524" layer="91"/>
-<wire x1="66.04" y1="48.26" x2="68.58" y2="48.26" width="0.1524" layer="91"/>
-<wire x1="68.58" y1="48.26" x2="68.58" y2="73.66" width="0.1524" layer="91"/>
-<wire x1="68.58" y1="73.66" x2="83.82" y2="73.66" width="0.1524" layer="91"/>
-<junction x="83.82" y="73.66"/>
+<pinref part="IC2" gate="G$1" pin="VCCA"/>
+<wire x1="111.76" y1="116.84" x2="114.3" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="114.3" y1="116.84" x2="114.3" y2="119.38" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="+5V" class="0">
 <segment>
 <pinref part="C1" gate="G$1" pin="1"/>
 <pinref part="P+1" gate="1" pin="+5V"/>
-<wire x1="12.7" y1="33.02" x2="12.7" y2="27.94" width="0.1524" layer="91"/>
-<pinref part="U1" gate="G$1" pin="IN"/>
-<wire x1="22.86" y1="27.94" x2="20.32" y2="27.94" width="0.1524" layer="91"/>
-<junction x="12.7" y="27.94"/>
-<pinref part="U1" gate="G$1" pin="EN"/>
-<wire x1="20.32" y1="27.94" x2="12.7" y2="27.94" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="22.86" x2="20.32" y2="22.86" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="22.86" x2="20.32" y2="27.94" width="0.1524" layer="91"/>
-<junction x="20.32" y="27.94"/>
+<pinref part="IC3" gate="G$1" pin="IN"/>
+<wire x1="50.8" y1="88.9" x2="48.26" y2="88.9" width="0.1524" layer="91"/>
+<pinref part="IC3" gate="G$1" pin="EN"/>
+<wire x1="50.8" y1="86.36" x2="48.26" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="86.36" x2="48.26" y2="88.9" width="0.1524" layer="91"/>
+<junction x="48.26" y="88.9"/>
+<wire x1="48.26" y1="88.9" x2="43.18" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="86.36" x2="43.18" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="88.9" x2="43.18" y2="91.44" width="0.1524" layer="91"/>
+<junction x="43.18" y="88.9"/>
 </segment>
 <segment>
 <pinref part="J1" gate="G$1" pin="4"/>
 <pinref part="P+2" gate="1" pin="+5V"/>
-<wire x1="22.86" y1="66.04" x2="22.86" y2="76.2" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="66.04" x2="10.16" y2="66.04" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="4"/>
-<junction x="22.86" y="66.04"/>
+<wire x1="50.8" y1="116.84" x2="60.96" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="134.62" x2="60.96" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="60.96" y1="134.62" x2="60.96" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="60.96" y1="134.62" x2="60.96" y2="139.7" width="0.1524" layer="91"/>
+<junction x="60.96" y="134.62"/>
 </segment>
 <segment>
 <pinref part="P+3" gate="1" pin="+5V"/>
-<pinref part="U$1" gate="G$1" pin="VCCB"/>
-<wire x1="53.34" y1="76.2" x2="53.34" y2="68.58" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="G$1" pin="VCCB"/>
+<wire x1="86.36" y1="116.84" x2="83.82" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="83.82" y1="116.84" x2="83.82" y2="119.38" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="SDO_OUT" class="0">
 <segment>
 <pinref part="R2" gate="G$1" pin="2"/>
-<wire x1="43.18" y1="58.42" x2="25.4" y2="58.42" width="0.1524" layer="91"/>
-<label x="38.1" y="58.42" size="1.778" layer="95" rot="MR0"/>
+<label x="66.04" y="111.76" size="1.27" layer="95" rot="MR0"/>
 <pinref part="J1" gate="G$1" pin="2"/>
-<wire x1="22.86" y1="60.96" x2="25.4" y2="60.96" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="60.96" x2="10.16" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="111.76" x2="55.88" y2="111.76" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="2"/>
-<junction x="22.86" y="60.96"/>
-<wire x1="25.4" y1="58.42" x2="25.4" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="66.04" y1="111.76" x2="55.88" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="129.54" x2="55.88" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="55.88" y1="129.54" x2="55.88" y2="111.76" width="0.1524" layer="91"/>
+<junction x="55.88" y="111.76"/>
 </segment>
 </net>
 <net name="SCK_OUT" class="0">
 <segment>
 <pinref part="J1" gate="G$1" pin="3"/>
-<wire x1="22.86" y1="63.5" x2="30.48" y2="63.5" width="0.1524" layer="91"/>
-<wire x1="22.86" y1="63.5" x2="10.16" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="114.3" x2="58.42" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="58.42" y1="114.3" x2="73.66" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="J2" gate="G$1" pin="3"/>
-<junction x="22.86" y="63.5"/>
 <pinref part="R1" gate="G$1" pin="2"/>
-<wire x1="43.18" y1="63.5" x2="40.64" y2="63.5" width="0.1524" layer="91"/>
-<label x="38.1" y="63.5" size="1.778" layer="95" rot="MR0"/>
-<wire x1="30.48" y1="63.5" x2="40.64" y2="63.5" width="0.1524" layer="91"/>
+<label x="68.58" y="114.3" size="1.27" layer="95" rot="MR0"/>
+<wire x1="50.8" y1="132.08" x2="58.42" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="58.42" y1="132.08" x2="58.42" y2="114.3" width="0.1524" layer="91"/>
+<junction x="58.42" y="114.3"/>
 </segment>
 </net>
 <net name="EN" class="0">
 <segment>
-<pinref part="IC1" gate="G$1" pin="EN"/>
 <pinref part="TP3" gate="G$1" pin="1"/>
 <pinref part="R3" gate="G$1" pin="2"/>
-<wire x1="157.48" y1="40.64" x2="162.56" y2="40.64" width="0.1524" layer="91"/>
-<junction x="162.56" y="40.64"/>
-<wire x1="162.56" y1="40.64" x2="165.1" y2="40.64" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="91.44" x2="190.5" y2="91.44" width="0.1524" layer="91"/>
+<junction x="190.5" y="91.44"/>
+<wire x1="190.5" y1="91.44" x2="193.04" y2="91.44" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="EN"/>
 </segment>
 </net>
 <net name="U0TX" class="0">
 <segment>
 <pinref part="TP2" gate="G$1" pin="1"/>
-<wire x1="127" y1="81.28" x2="127" y2="76.2" width="0.1524" layer="91"/>
-<pinref part="IC1" gate="G$1" pin="U0TXD"/>
+<wire x1="154.94" y1="132.08" x2="154.94" y2="127" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="U0TXD"/>
 </segment>
 </net>
 <net name="UORX" class="0">
 <segment>
-<pinref part="IC1" gate="G$1" pin="U0RXD"/>
-<wire x1="124.46" y1="76.2" x2="124.46" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="152.4" y1="127" x2="152.4" y2="132.08" width="0.1524" layer="91"/>
 <pinref part="TP1" gate="G$1" pin="1"/>
+<pinref part="IC4" gate="G$1" pin="U0RXD"/>
 </segment>
 </net>
 <net name="IO0" class="0">
 <segment>
-<pinref part="IC1" gate="G$1" pin="IO0"/>
-<wire x1="106.68" y1="20.32" x2="106.68" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="147.32" y1="68.58" x2="147.32" y2="63.5" width="0.1524" layer="91"/>
 <pinref part="TP4" gate="G$1" pin="1"/>
-<wire x1="106.68" y1="12.7" x2="101.6" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="IO0"/>
 </segment>
 </net>
 <net name="SCK" class="0">
 <segment>
-<wire x1="83.82" y1="63.5" x2="86.36" y2="63.5" width="0.1524" layer="91"/>
-<wire x1="86.36" y1="63.5" x2="83.82" y2="63.5" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="A1"/>
-<pinref part="IC1" gate="G$1" pin="IO18"/>
-<wire x1="91.44" y1="63.5" x2="88.9" y2="63.5" width="0.1524" layer="91"/>
-<wire x1="83.82" y1="63.5" x2="88.9" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="G$1" pin="A1"/>
+<wire x1="129.54" y1="109.22" x2="121.92" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="121.92" y1="109.22" x2="116.84" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="114.3" x2="111.76" y2="114.3" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="IO18"/>
 </segment>
 </net>
 <net name="SDO" class="0">
 <segment>
-<wire x1="83.82" y1="58.42" x2="86.36" y2="58.42" width="0.1524" layer="91"/>
-<wire x1="86.36" y1="58.42" x2="83.82" y2="58.42" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="A2"/>
-<wire x1="83.82" y1="58.42" x2="86.36" y2="58.42" width="0.1524" layer="91"/>
-<wire x1="86.36" y1="58.42" x2="86.36" y2="66.04" width="0.1524" layer="91"/>
-<pinref part="IC1" gate="G$1" pin="IO23"/>
-<wire x1="91.44" y1="66.04" x2="88.9" y2="66.04" width="0.1524" layer="91"/>
-<wire x1="86.36" y1="66.04" x2="88.9" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="G$1" pin="A2"/>
+<wire x1="111.76" y1="111.76" x2="129.54" y2="111.76" width="0.1524" layer="91"/>
+<pinref part="IC4" gate="G$1" pin="IO23"/>
 </segment>
 </net>
 <net name="N$4" class="0">
 <segment>
-<pinref part="U$1" gate="G$1" pin="B1"/>
+<pinref part="IC2" gate="G$1" pin="B1"/>
 <pinref part="R1" gate="G$1" pin="1"/>
+<wire x1="83.82" y1="114.3" x2="86.36" y2="114.3" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$5" class="0">
 <segment>
-<pinref part="U$1" gate="G$1" pin="B2"/>
+<pinref part="IC2" gate="G$1" pin="B2"/>
 <pinref part="R2" gate="G$1" pin="1"/>
+<wire x1="76.2" y1="111.76" x2="86.36" y2="111.76" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$2" class="0">
 <segment>
-<pinref part="IC1" gate="G$1" pin="IO14"/>
-<wire x1="121.92" y1="20.32" x2="121.92" y2="15.24" width="0.1524" layer="91"/>
-<wire x1="121.92" y1="15.24" x2="121.92" y2="12.7" width="0.1524" layer="91"/>
-<pinref part="D1" gate="G$1" pin="A"/>
+<wire x1="162.56" y1="68.58" x2="162.56" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="LEDD1" gate="G$1" pin="A"/>
+<pinref part="IC4" gate="G$1" pin="IO14"/>
 </segment>
 </net>
 <net name="N$3" class="0">
 <segment>
-<pinref part="D1" gate="G$1" pin="C"/>
+<pinref part="LEDD1" gate="G$1" pin="C"/>
 <pinref part="R4" gate="G$1" pin="2"/>
-<wire x1="132.08" y1="12.7" x2="129.54" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="162.56" y1="55.88" x2="162.56" y2="58.42" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$6" class="0">
 <segment>
-<pinref part="IC1" gate="G$1" pin="LNA_IN"/>
-<wire x1="157.48" y1="58.42" x2="172.72" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="109.22" x2="200.66" y2="109.22" width="0.1524" layer="91"/>
 <pinref part="C6" gate="G$1" pin="2"/>
-<pinref part="L1" gate="G$1" pin="2"/>
-<wire x1="172.72" y1="58.42" x2="172.72" y2="59.69" width="0.1524" layer="91"/>
-<junction x="172.72" y="58.42"/>
+<wire x1="200.66" y1="109.22" x2="200.66" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="109.22" x2="200.66" y2="109.22" width="0.1524" layer="91"/>
+<junction x="200.66" y="109.22"/>
+<pinref part="L2" gate="G$1" pin="P$1"/>
+<pinref part="IC4" gate="G$1" pin="LNA_IN"/>
 </segment>
 </net>
 <net name="BUTTON" class="0">
 <segment>
 <pinref part="S1" gate="G$1" pin="2"/>
-<wire x1="170.18" y1="27.94" x2="170.18" y2="33.02" width="0.1524" layer="91"/>
-<pinref part="IC1" gate="G$1" pin="IO32"/>
-<wire x1="157.48" y1="33.02" x2="160.02" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="33.02" x2="165.1" y2="33.02" width="0.1524" layer="91"/>
-<label x="167.64" y="33.02" size="1.778" layer="95" rot="MR0"/>
-<wire x1="170.18" y1="33.02" x2="165.1" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="83.82" x2="195.58" y2="83.82" width="0.1524" layer="91"/>
+<label x="195.58" y="83.82" size="1.27" layer="95" rot="MR0"/>
+<pinref part="IC4" gate="G$1" pin="IO32"/>
 </segment>
 </net>
 </nets>
@@ -6295,6 +5842,11 @@ will not be understood (or retained) with this version.
 Since Version 8.3, EAGLE supports the association of 3D packages
 with devices in libraries, schematics, and board files. Those 3D
 packages will not be understood (or retained) with this version.
+</note>
+<note version="9.4" severity="warning">
+Since Version 9.4, EAGLE supports the overriding of 3D packages
+in schematics and board files. Those overridden 3d packages
+will not be understood (or retained) with this version.
 </note>
 </compatibility>
 </eagle>


### PR DESCRIPTION
I really like this project (although still had no chance to try it myself). But I noticed that the quality of the hardware source files does not match the quality of the software. This is understandable, no one can do everything perfectly.
So I tried my best to format the hardware side of Pixelblaze PICO better. Couple important notices:
- The schematic was not changed. Everything is still connected exactly the same way it was before.
- Component placement was not changed. All the components are still in the same places as they were before

And now to the changelog:
- All the parts were replaced with better ones. For passive parts also footprints were replaced with more IPC compatible ones (0% problems when reflow soldering)
- Schematic symbols for all parts were redone for the schamatic to look good and be more readable. 
- DRC settings were updated (DRC settings for JLCPCB were used which are compatible with majority of PCB manufacturers)
- Vias diameter reduced from 0.35 to 0.3 mm fix some clearance errors
- All the parts were moved to managed libraries, missing 3d models were added. This allowed me to generate a complete 3d model of the device, which is available [here](https://a360.co/36E3eFM).
- Routing was enhanced where needed (less closed angles and shorter signal paths overall)
- All the traces were rounded where possible for aesthetic reasons.
I hope you will find this PR appropriate. If so, there are some more things that can be done to this PCB to make it even better, let me know.

A couple screenshots of the 3d model just for the reference:
![image](https://user-images.githubusercontent.com/9300016/164893099-85376c93-1450-47c5-9cfd-ca2009d7cdb8.png)
![image](https://user-images.githubusercontent.com/9300016/164893119-e7bcb354-a0d7-4c86-8cbc-b4251db9fe92.png)
 