### PR TITLE
Update Pixelblaze link to current domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pixelblaze
 
-This repo includes open source information related to [Pixelblaze](https://www.bhencke.com/pixelblaze).
+This repo includes open source information related to [Pixelblaze](https://electromage.com/pixelblaze).
 
 * [Pattern code Reference](README.expressions.md)
 * [Mapper code Reference](README.mapper.md)


### PR DESCRIPTION
The new link sends folks directly to electromage.com/pixelblaze. Guessing the prior link was something legacy, but figured this gets folks to the destination quicker. And one less thing that can break. (Feel free to close if the redirect is providing something useful, though.)